### PR TITLE
Entirely disable quality control in the task generation script if requested

### DIFF
--- a/Examples/DocLevelDA/README.md
+++ b/Examples/DocLevelDA/README.md
@@ -6,7 +6,7 @@ Generating an example document-level evaluation WMT19 campaign:
         Examples/DocLevelDA/sources/newstest2019-ende-src.en.sgm \
         Examples/DocLevelDA/references/newstest2019-ende-ref.de.sgm \
         Examples/DocLevelDA/system-outputs/ '*.sgm' \
-        Examples/DocLevelDA/batches eng deu 2 false \
+        Examples/DocLevelDA/batches eng deu 2 true \
         | tee Examples/DocLevelDA/batches.log
 
     python manage.py init_campaign Examples/DocLevelDA/manifest.json

--- a/create_wmt19_tasks.py
+++ b/create_wmt19_tasks.py
@@ -230,12 +230,13 @@ if __name__ == "__main__":
     SRC_LANG = sys.argv[6]        # Code for source language, e.g. eng
     TGT_LANG = sys.argv[7]        # Code for target language, e.g. deu
     TASK_MAX = int(sys.argv[8])   # Maximum number of tasks
-    CONTROLS = bool(sys.argv[9])
+    CONTROLS = sys.argv[9].lower() not in ['', '0', 'false', 'off']
     ENC = 'utf-8'
 
     RND_SEED = 123456
     seed(RND_SEED)
 
+    print(f'Quality control={CONTROLS}')
     if CONTROLS:
         REQUIRED_SEGS = 80
     else:
@@ -345,7 +346,7 @@ if __name__ == "__main__":
     shuffle(sampled_tasks)
 
     padded_tasks: List[Tuple[Tuple[int, str, str], ...]] = []
-    for task in sampled_tasks:
+    for tid, task in enumerate(sampled_tasks):
         task_docs = len(task)
         task_len = sum([x[0] for x in task])
         print(f'task_len: {task_len}')
@@ -378,7 +379,8 @@ if __name__ == "__main__":
             print(padded_tasks[-1])
 
         else:
-            raise NotImplementedError('Needs isControl=True update!')
+            print(f'WARNING: no control items in task no. {tid}')
+            # raise NotImplementedError('Needs isControl=True update!')
             padded_tasks.append(tuple(task))  # TODO: does this ever occur?
 
     csv_data = []
@@ -467,7 +469,7 @@ if __name__ == "__main__":
 
                 target_text = item_tgt
                 target_type = 'TGT'
-                if isControl:
+                if CONTROLS and isControl:  # Do not generate any BAD items if QC is disabled
                     randomCoinFlip = choice(
                         [False, False, True, True, True]  # 60:40 chance
                     )


### PR DESCRIPTION
`create_wmt19_tasks.py` could still generate some BAD items even if `CONTROLS` was set to false from the command line. This PR properly disables quality control if requested.

Changes proposed in the pull request:
- Do not generate BAD items if `CONTROLS` is set to false from the command line.
- `CONTROLS` can be disabled via `"0", "false", "off"` too (case insensitive), not only by an empty string `""`.

@AppraiseDev/core-team
