### PR TITLE
Quote fields with special characters in the CSV export

### DIFF
--- a/Campaign/management/commands/ExportSystemScoresToCSV.py
+++ b/Campaign/management/commands/ExportSystemScoresToCSV.py
@@ -26,6 +26,9 @@ CAMPAIGN_TASK_TYPES = (
     (PairwiseAssessmentTask, PairwiseAssessmentResult),
 )
 
+import csv
+import sys
+
 
 class Command(BaseCommand):
     help = 'Exports system scores over all results to CSV format'
@@ -53,6 +56,7 @@ class Command(BaseCommand):
         except LookupError as error:
             raise CommandError(error)
 
+        csv_writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
         system_scores = []
         for task_cls, result_cls in CAMPAIGN_TASK_TYPES:
             qs_name = task_cls.__name__.lower()
@@ -70,4 +74,4 @@ class Command(BaseCommand):
                 system_scores.extend(_scores)
 
         for system_score in system_scores:
-            print(','.join([str(x) for x in system_score]))
+            csv_writer.writerow([str(x) for x in system_score])

--- a/Campaign/management/commands/ExportSystemScoresToCSV.py
+++ b/Campaign/management/commands/ExportSystemScoresToCSV.py
@@ -1,4 +1,7 @@
 # pylint: disable=C0103,C0111,C0330,E1101
+import csv
+import sys
+
 from django.core.management.base import BaseCommand, CommandError
 
 from Campaign.models import Campaign
@@ -25,9 +28,6 @@ CAMPAIGN_TASK_TYPES = (
     (MultiModalAssessmentTask, MultiModalAssessmentResult),
     (PairwiseAssessmentTask, PairwiseAssessmentResult),
 )
-
-import csv
-import sys
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Batches of data assessment tasks contain document URLs that may contain a comma. If so, those rows in the exported CSV file are not properly formatted. This PR fixes that issue by using a CSV writer that quotes fields if necessary, to keep the expected format.

Changes proposed in the pull request:
- Generate rows using `csv`, which can automatically quote minimal special characters (https://docs.python.org/3/library/csv.html#csv.QUOTE_MINIMAL)

@AppraiseDev/core-team
