### PR TITLE
Add batch and item IDs into CSV files with exported scores

### DIFF
--- a/Campaign/management/commands/ExportSystemScoresToCSV.py
+++ b/Campaign/management/commands/ExportSystemScoresToCSV.py
@@ -41,6 +41,11 @@ class Command(BaseCommand):
             action='store_true',
             help='Include completed tasks only in the computation',
         )
+        parser.add_argument(
+            '--batch-info',
+            action='store_true',
+            help='Export batch and item IDs to help matching the scores to items in the JSON batches',
+        )
         # TODO: add argument to specify batch user
 
     def handle(self, *args, **options):
@@ -65,7 +70,8 @@ class Command(BaseCommand):
 
             if qs_obj and qs_obj.exists():
                 _scores = result_cls.get_system_data(
-                    campaign.id, extended_csv=True
+                    campaign.id, extended_csv=True,
+                    add_batch_info=options['batch_info']
                 )
                 system_scores.extend(_scores)
 

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -819,7 +819,14 @@ class DataAssessmentResult(BaseMetadata):
 
 
     @classmethod
-    def get_system_data(cls, campaign_id, extended_csv=False, expand_multi_sys=True, include_inactive=False):
+    def get_system_data(
+        cls,
+        campaign_id,
+        extended_csv=False,
+        expand_multi_sys=True,
+        include_inactive=False,
+        add_batch_info=False,
+    ):
         system_data = []
 
         item_types = ('TGT', 'CHK')
@@ -852,6 +859,12 @@ class DataAssessmentResult(BaseMetadata):
             attributes_to_extract = attributes_to_extract + (
               'start_time',                 # Start time
               'end_time'                    # End time
+            )
+
+        if add_batch_info:
+            attributes_to_extract = attributes_to_extract + (
+              'task__batchNo',  # Batch number
+              'item_id'         # Real item ID
             )
 
         for result in qs.values_list(*attributes_to_extract):

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -700,7 +700,14 @@ class DirectAssessmentResult(BaseMetadata):
 
 
     @classmethod
-    def get_system_data(cls, campaign_id, extended_csv=False, expand_multi_sys=True, include_inactive=False):
+    def get_system_data(
+        cls,
+        campaign_id,
+        extended_csv=False,
+        expand_multi_sys=True,
+        include_inactive=False,
+        add_batch_info=False,
+    ):
         system_data = []
 
         item_types = ('TGT', 'CHK')
@@ -730,6 +737,12 @@ class DirectAssessmentResult(BaseMetadata):
             attributes_to_extract = attributes_to_extract + (
               'start_time',                 # Start time
               'end_time'                    # End time
+            )
+
+        if add_batch_info:
+            attributes_to_extract = attributes_to_extract + (
+              'task__batchNo',  # Batch number
+              'item_id'         # Real item ID
             )
 
         for result in qs.values_list(*attributes_to_extract):

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -769,7 +769,14 @@ class DirectAssessmentContextResult(BaseMetadata):
 
 
     @classmethod
-    def get_system_data(cls, campaign_id, extended_csv=False, expand_multi_sys=True, include_inactive=False):
+    def get_system_data(
+        cls,
+        campaign_id,
+        extended_csv=False,
+        expand_multi_sys=True,
+        include_inactive=False,
+        add_batch_info=False,
+    ):
         system_data = []
 
         item_types = ('TGT', 'CHK')
@@ -801,6 +808,12 @@ class DirectAssessmentContextResult(BaseMetadata):
             attributes_to_extract = attributes_to_extract + (
               'start_time',                 # Start time
               'end_time'                    # End time
+            )
+
+        if add_batch_info:
+            attributes_to_extract = attributes_to_extract + (
+              'task__batchNo',  # Batch number
+              'item_id'         # Real item ID
             )
 
         for result in qs.values_list(*attributes_to_extract):

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -809,7 +809,14 @@ class DirectAssessmentDocumentResult(BaseMetadata):
 
 
     @classmethod
-    def get_system_data(cls, campaign_id, extended_csv=False, expand_multi_sys=True, include_inactive=False):
+    def get_system_data(
+        cls,
+        campaign_id,
+        extended_csv=False,
+        expand_multi_sys=True,
+        include_inactive=False,
+        add_batch_info=False,
+    ):
         system_data = []
 
         item_types = ('TGT', 'CHK')
@@ -841,6 +848,12 @@ class DirectAssessmentDocumentResult(BaseMetadata):
             attributes_to_extract = attributes_to_extract + (
               'start_time',                 # Start time
               'end_time'                    # End time
+            )
+
+        if add_batch_info:
+            attributes_to_extract = attributes_to_extract + (
+              'task__batchNo',  # Batch number
+              'item_id'         # Real item ID
             )
 
         for result in qs.values_list(*attributes_to_extract):

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -887,7 +887,14 @@ class PairwiseAssessmentResult(BaseMetadata):
 
 
     @classmethod
-    def get_system_data(cls, campaign_id, extended_csv=False, expand_multi_sys=True, include_inactive=False):
+    def get_system_data(
+        cls,
+        campaign_id,
+        extended_csv=False,
+        expand_multi_sys=True,
+        include_inactive=False,
+        add_batch_info=False,
+    ):
         system_data = []
 
         item_types = ('TGT', 'CHK')
@@ -918,8 +925,14 @@ class PairwiseAssessmentResult(BaseMetadata):
 
         if extended_csv:
             attributes_to_extract = attributes_to_extract + (
-              'start_time',                 # Start time
-              'end_time'                    # End time
+              'start_time',     # Start time
+              'end_time'        # End time
+            )
+
+        if add_batch_info:
+            attributes_to_extract = attributes_to_extract + (
+              'task__batchNo',  # Batch number
+              'item_id'         # Real item ID
             )
 
         for _result in qs.values_list(*attributes_to_extract):
@@ -932,24 +945,17 @@ class PairwiseAssessmentResult(BaseMetadata):
                     continue
 
                 user_id = result[0]
-
-                _fixed_ids = result[1].replace(
-                  'Transformer+R2L', 'Transformer_R2L'
-                )
-                _fixed_ids = _fixed_ids.replace(
-                  'R2L+Back', 'R2L_Back'
-                )
-
+                sys_ids = result[1]
 
                 if expand_multi_sys:
-                    system_ids = _fixed_ids.split('+')
+                    system_ids = sys_ids.split('+')
 
                     for system_id in system_ids:
                         data = (user_id,) + (system_id,) + result[2:]
                         system_data.append(data)
 
                 else:
-                    system_id = _fixed_ids
+                    system_id = sys_ids
                     data = (user_id,) + (system_id,) + result[2:]
                     system_data.append(data)
 

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -940,8 +940,13 @@ class PairwiseAssessmentResult(BaseMetadata):
               (_result[0], _result[1], _result[3], _result[4], _result[5], _result[6], _result[7], *_result[9:]),
               (_result[0], _result[2], _result[3], _result[4], _result[5], _result[6], _result[8], *_result[9:]),
             ]
+
+            if add_batch_info:  # Add index of the target segment
+                results[0] = (*results[0], 0)
+                results[1] = (*results[1], 1)
+
             for result in results:
-                if result[1] is None:
+                if result[1] is None:   # Ignore if this was an item with only one target segment
                     continue
 
                 user_id = result[0]


### PR DESCRIPTION
This PR adds a new option to the export script that, if enabled, adds two new columns into the CSV file with exported scores with batch number and item ID. This will help match exported scores with items from the input JSON batches, especially for pairwise tasks with expanded systems IDs.

Note that item ID is the item ID from the database, not the `_item` field from the batch, because it's not loaded into the database when a campaign is created. But that's sufficient to track back items from the JSON batch.

Related issues: #5 

Changes proposed in the pull request:
- Added `--add-batch-info` to `ExportSystemScoresToCSV.py`.
- When enabled, two new columns are added to the exported scores: batch number, and item ID.
- For pairwise tasks, a third column with target ID is added additionally.

@AppraiseDev/core-team
