### PR TITLE
Task confirmation tokens for shallow integration with external apps

### DIFF
--- a/Campaign/management/commands/init_campaign.py
+++ b/Campaign/management/commands/init_campaign.py
@@ -21,6 +21,8 @@ from Campaign.utils import (
     CAMPAIGN_TASK_TYPES,
 )
 
+from Dashboard.utils import generate_confirmation_token
+
 # pylint: disable=C0111,C0330,E1101
 class Command(BaseCommand):
     help = 'Initialises campaign based on manifest file'
@@ -48,11 +50,19 @@ class Command(BaseCommand):
             metavar='--xlsx',
             help='Path used to create Excel file containing credentials.',
         )
+
         parser.add_argument(
             '--include-completed',
             action='store_true',
             default=False,
-            help='Include completed tasks in task agenda re-assignment',
+            help='Include completed tasks in task agenda re-assignment.',
+        )
+
+        parser.add_argument(
+            '--task-confirmation-tokens',
+            action='store_true',
+            default=False,
+            help='Generate valid task confirmation tokens needed for integration with external crowd sourcing apps.',
         )
 
     def handle(self, *args, **options):
@@ -85,23 +95,26 @@ class Command(BaseCommand):
         # By default, we only include activated tasks into agenda creation.
         # Compute Boolean flag based on negation of --include-completed state.
         only_activated = not options['include_completed']
+        expected_tokens = options['task_confirmation_tokens']
 
         # Initialise campaign based on manifest data
         self.init_campaign(
-            manifest_data, csv_output, xlsx_output, only_activated
+            manifest_data, csv_output, xlsx_output, only_activated,
+            expected_tokens
         )
 
     def init_campaign(
-        self, manifest_data, csv_output, xlsx_output, only_activated=True
+        self, manifest_data, csv_output, xlsx_output, only_activated=True,
+        expected_tokens=False
     ):
-        '''Initialises campaign based on manifest data.
+        """Initialises campaign based on manifest data.
 
         Parameters:
         - manifest_data:dict[str]->any dictionary containing manifest data;
         - csv_output:str path to CSV output file, or None;
         - xlsx_output:str path to Excel output file, or None;
         - only_activated:bool only include activated tasks for agenda creation.
-        '''
+        """
 
         # TODO: refactor into _create_context()
         GENERATORS = {'uniform': _create_uniform_task_map}
@@ -109,7 +122,13 @@ class Command(BaseCommand):
         ALL_LANGUAGE_CODES = set()
         TASKS_TO_ANNOTATORS = {}
         for pair_data in manifest_data['TASKS_TO_ANNOTATORS']:
-            source_code, target_code, mode, num_annotators, num_tasks = pair_data
+            (
+                source_code,
+                target_code,
+                mode,
+                num_annotators,
+                num_tasks,
+            ) = pair_data
 
             # Validation needs access to full language codes,
             # including any script specification
@@ -120,7 +139,9 @@ class Command(BaseCommand):
 
             generator = GENERATORS[mode]
             TASKS_TO_ANNOTATORS[(source_code, target_code)] = generator(
-                num_annotators, num_tasks, manifest_data['REDUNDANCY'],
+                num_annotators,
+                num_tasks,
+                manifest_data['REDUNDANCY'],
             )
 
         _validate_language_codes(ALL_LANGUAGE_CODES)
@@ -129,8 +150,9 @@ class Command(BaseCommand):
         TASK_TYPE = manifest_data.get('TASK_TYPE', 'Direct')
         # Raise an exception if an unrecognized task type is provided
         if TASK_TYPE not in CAMPAIGN_TASK_TYPES:
-            _msg = 'Unrecognized TASK_TYPE \'{0}\'. Supported tasks are: {1}' \
-                    .format(TASK_TYPE, ', '.join(CAMPAIGN_TASK_TYPES.keys()))
+            _msg = 'Unrecognized TASK_TYPE \'{0}\'. Supported tasks are: {1}'.format(
+                TASK_TYPE, ', '.join(CAMPAIGN_TASK_TYPES.keys())
+            )
             raise ValueError(_msg)
 
         CONTEXT = {
@@ -170,13 +192,20 @@ class Command(BaseCommand):
 
         # Generate Dataset with user credentials and SSO URLs
         export_data = Dataset()
-        export_data.headers = ('Username', 'Password', 'URL')
+        if expected_tokens:
+            export_data.headers = ('Username', 'Password', 'URL', 'ExpectedToken')
+        else:
+            export_data.headers = ('Username', 'Password', 'URL')
         export_data.title = datetime.strftime(datetime.now(), '%Y%m%d')
 
         base_url = manifest_data['CAMPAIGN_URL']
         for _user, _password in credentials.items():
             _url = '{0}{1}/{2}/'.format(base_url, _user, _password)
-            export_data.append((_user, _password, _url))
+            if expected_tokens:
+                _token = generate_confirmation_token(username, run_qc=False)
+                export_data.append((_user, _password, _url, _token))
+            else:
+                export_data.append((_user, _password, _url))
 
         # Export credentials to CSV or Excel files, if specified
         self.export_credentials(export_data, csv_output, xlsx_output)
@@ -191,13 +220,13 @@ class Command(BaseCommand):
         )
 
     def export_credentials(self, export_data, csv_output, xlsx_output):
-        '''Export credentials to screen, CSV and Excel files.
+        """Export credentials to screen, CSV and Excel files.
 
         Parameters:
         - export_data:Dataset contains triples (username, password, url);
         - csv_output:str path to CSV output file, or None;
         - xlsx_output:str path to Excel output file, or None.
-        '''
+        """
 
         # Write credentials to CSV file if specified.
         if csv_output:

--- a/Campaign/management/commands/init_campaign.py
+++ b/Campaign/management/commands/init_campaign.py
@@ -95,17 +95,17 @@ class Command(BaseCommand):
         # By default, we only include activated tasks into agenda creation.
         # Compute Boolean flag based on negation of --include-completed state.
         only_activated = not options['include_completed']
-        expected_tokens = options['task_confirmation_tokens']
+        confirmation_tokens = options['task_confirmation_tokens']
 
         # Initialise campaign based on manifest data
         self.init_campaign(
             manifest_data, csv_output, xlsx_output, only_activated,
-            expected_tokens
+            confirmation_tokens
         )
 
     def init_campaign(
         self, manifest_data, csv_output, xlsx_output, only_activated=True,
-        expected_tokens=False
+        confirmation_tokens=False
     ):
         """Initialises campaign based on manifest data.
 
@@ -113,7 +113,8 @@ class Command(BaseCommand):
         - manifest_data:dict[str]->any dictionary containing manifest data;
         - csv_output:str path to CSV output file, or None;
         - xlsx_output:str path to Excel output file, or None;
-        - only_activated:bool only include activated tasks for agenda creation.
+        - only_activated:bool only include activated tasks for agenda creation;
+        - confirmation_tokens:bool export valid task confirmation tokens.
         """
 
         # TODO: refactor into _create_context()
@@ -192,8 +193,8 @@ class Command(BaseCommand):
 
         # Generate Dataset with user credentials and SSO URLs
         export_data = Dataset()
-        if expected_tokens:
-            export_data.headers = ('Username', 'Password', 'URL', 'ExpectedToken')
+        if confirmation_tokens:
+            export_data.headers = ('Username', 'Password', 'URL', 'ConfirmationToken')
         else:
             export_data.headers = ('Username', 'Password', 'URL')
         export_data.title = datetime.strftime(datetime.now(), '%Y%m%d')
@@ -201,7 +202,7 @@ class Command(BaseCommand):
         base_url = manifest_data['CAMPAIGN_URL']
         for _user, _password in credentials.items():
             _url = '{0}{1}/{2}/'.format(base_url, _user, _password)
-            if expected_tokens:
+            if confirmation_tokens:
                 _token = generate_confirmation_token(username, run_qc=False)
                 export_data.append((_user, _password, _url, _token))
             else:
@@ -223,7 +224,8 @@ class Command(BaseCommand):
         """Export credentials to screen, CSV and Excel files.
 
         Parameters:
-        - export_data:Dataset contains triples (username, password, url);
+        - export_data:Dataset contains triples or 4-tuples (username,
+          password, url, [token]);
         - csv_output:str path to CSV output file, or None;
         - xlsx_output:str path to Excel output file, or None.
         """

--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -159,6 +159,7 @@ def campaign_status(request, campaign_name, sort_key=2):
                     _reliable = pvalue
 
                 except ImportError:
+                    print("scipy is not installed")
                     pass
 
                 # Possible for mannwhitneyu() to throw in some scenarios:

--- a/Dashboard/templates/Dashboard/dashboard.html
+++ b/Dashboard/templates/Dashboard/dashboard.html
@@ -34,7 +34,7 @@
 {% elif work_completed %}
             <h3>Work completed</h3>
             <p>You have successfully completed all tasks assigned to you. Thank you very much!</p>
-            <p>Below is your unique task confirmation token. You may need it to confirm that you have finished all tasks.</p>
+            <p>This is your unique confirmation token, which you may need to certify that you have completed the work.</p>
             <div class="row">
               <div class="col-sm-6 col-sm-offset-3 text-center alert alert-info">
                 <p>{{ work_completed }}</p>

--- a/Dashboard/templates/Dashboard/dashboard.html
+++ b/Dashboard/templates/Dashboard/dashboard.html
@@ -34,6 +34,12 @@
 {% elif work_completed %}
             <h3>Work completed</h3>
             <p>You have successfully completed all tasks assigned to you. Thank you very much!</p>
+            <p>Below is your unique task confirmation token. You may need it to confirm that you have finished all tasks.</p>
+            <div class="row">
+              <div class="col-sm-6 col-sm-offset-3 text-center alert alert-info">
+                <p>{{ work_completed }}</p>
+              </div>
+            </div>
 {% else %}
             <h3>Next HIT</h3>
             <p>We are currently finalising the registration process for annotator accounts. Once this has been completed, direct assessment tasks will be become available from this page. Please check back in a little while.</p>

--- a/Dashboard/utils.py
+++ b/Dashboard/utils.py
@@ -1,0 +1,151 @@
+"""
+Appraise evaluation framework
+
+See LICENSE for usage details
+"""
+from collections import defaultdict
+from datetime import datetime
+from hashlib import md5
+from math import floor, sqrt
+from scipy.stats import mannwhitneyu
+from uuid import UUID
+
+from Appraise.settings import SECRET_KEY
+from EvalData.models import (
+    DataAssessmentResult,
+    DirectAssessmentResult,
+    DirectAssessmentContextResult,
+    DirectAssessmentDocumentResult,
+    MultiModalAssessmentResult,
+    PairwiseAssessmentResult,
+)
+
+RESULT_TYPES = {
+    DataAssessmentResult,
+    DirectAssessmentResult,
+    DirectAssessmentContextResult,
+    DirectAssessmentDocumentResult,
+    MultiModalAssessmentResult,
+    PairwiseAssessmentResult,
+}
+
+# Maximum allowed p-value for the Wilcoxon rank-sum test
+MAX_WILCOXON_PVALUE = 0.010
+
+# Minimum allowed total annotation time for a task
+MIN_ANNOTATION_TIME = 600  # i.e. 10 minutes
+
+
+def generate_confirmation_token(username, run_qc=True):
+    """
+    Generates a token for completed work.
+
+    Returns a success token if he quality control is not run.
+    """
+    if run_qc == True:
+        status = 'SUCCESS' if quality_control(username) else 'FAILED'
+        seed = SECRET_KEY + username + status
+    else:
+        seed = SECRET_KEY + username + 'SUCCESS'
+
+    token = md5()
+    token.update(seed.encode('utf-8'))
+    new_uuid = UUID(token.hexdigest())
+    return new_uuid
+
+
+def quality_control(username):
+    """
+    Runs quality control for the user.
+    """
+    _data = None
+    result_type = None
+    for _type in RESULT_TYPES:
+        _data = _type.objects.filter(createdBy__username=username, completed=True)
+        # Get the first result task type available: might not work in all scenarios
+        if _data:
+            result_type = _type
+            break
+
+    if result_type is None:  # No items are completed yet
+        return None
+
+    if result_type is PairwiseAssessmentResult:
+        _data = _data.values_list(
+            'start_time',
+            'end_time',
+            'score1',
+            'item__itemID',
+            'item__target1ID',
+            'item__itemType',
+            'item__id',
+        )
+    else:
+        _data = _data.values_list(
+            'start_time',
+            'end_time',
+            'score',
+            'item__itemID',
+            'item__targetID',
+            'item__itemType',
+            'item__id',
+        )
+
+    _annotations = len(set([x[6] for x in _data]))
+
+    _user_mean = sum([x[2] for x in _data]) / (_annotations or 1)
+
+    _cs = _annotations - 1  # Corrected sample size for stdev.
+    _user_stdev = 1
+    if _cs > 0:
+        _user_stdev = sqrt(
+            sum(((x[2] - _user_mean) ** 2 / _cs) for x in _data)
+        )
+
+    if int(_user_stdev) == 0:
+        _user_stdev = 1
+
+    # Extract pairs for the Wilcoxon test
+    _tgt = defaultdict(list)
+    _bad = defaultdict(list)
+    for _x in _data:
+        if _x[-2] == 'TGT':
+            _dst = _tgt
+        elif _x[-2] == 'BAD':
+            _dst = _bad
+        else:
+            continue
+
+        _z_score = (_x[2] - _user_mean) / _user_stdev
+        _key = '{0}-{1}'.format(_x[3], _x[4])
+        _dst[_key].append(_z_score)
+
+    _x = []
+    _y = []
+    for _key in set.intersection(set(_tgt.keys()), set(_bad.keys())):
+        _x.append(sum(_bad[_key]) / float(len(_bad[_key] or 1)))
+        _y.append(sum(_tgt[_key]) / float(len(_tgt[_key] or 1)))
+
+    # Run the Wilcoxon rank-sum test
+    pvalue = None
+    if _x and _y:
+        try:
+            _t, _pvalue = mannwhitneyu(_x, _y, alternative='less')
+            pvalue = _pvalue
+        # Possible for mannwhitneyu() to throw in some scenarios:
+        #
+        # File "scipy/stats/stats.py", line 4865, in mannwhitneyu
+        #   raise ValueError(
+        #     'All numbers are identical in mannwhitneyu')
+        except ValueError:
+            pass
+
+    # Compute the total annotation time
+    _durations = [x[1] - x[0] for x in _data]
+    annotation_time = sum(_durations) if _durations else None
+
+    print("User '{}', items= {}, p-value= {}, time= {}".format(
+            username, len(_x), pvalue, annotation_time))
+
+    return pvalue is not None and pvalue <= MAX_WILCOXON_PVALUE \
+        and annotation_time is not None and annotation_time >= MIN_ANNOTATION_TIME

--- a/Dashboard/views.py
+++ b/Dashboard/views.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from hashlib import md5
 from inspect import currentframe, getframeinfo
 
+
 # pylint: disable=import-error,C0330
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User, Group
@@ -16,6 +17,7 @@ from django.shortcuts import render, redirect, render_to_response
 from Appraise.settings import BASE_CONTEXT
 from Appraise.utils import _get_logger
 from Dashboard.models import UserInviteToken, LANGUAGE_CODES_AND_NAMES
+from Dashboard.utils import generate_confirmation_token
 from EvalData.models import (
     DataAssessmentTask,
     DataAssessmentResult,
@@ -352,9 +354,9 @@ def dashboard(request):
     template_context = {'active_page': 'dashboard'}
     template_context.update(BASE_CONTEXT)
 
-    annotations = 0
-    hits = 0
-    total_hits = 0
+    annotations = 0  # Completed items
+    hits = 0         # Completed HITs
+    total_hits = 0   # Total number of HITs expected from the user
     for result_cls in TASK_RESULTS:
         annotations += result_cls.get_completed_for_user(request.user)
         _hits, _total = result_cls.get_hit_status_for_user(request.user)
@@ -532,6 +534,10 @@ def dashboard(request):
 
     current_url = TASK_URLS[current_type]
     print('  URL: {0}'.format(current_url))
+
+    # Provide UUID for the completed task
+    if work_completed:
+        work_completed = generate_confirmation_token(request.user.username, run_qc=True)
 
     template_context.update(times)
     template_context.update(

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -465,6 +465,7 @@ class DirectAssessmentResult(BaseMetadata):
             user_data[user_item[0]] += 1
 
         total_hits = len(user_data.keys())
+        # TODO: What is this magic number 70?
         completed_hits = len([x for x in user_data.values() if x >= 70])
 
         return (completed_hits, total_hits)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ bs4
 django>=2.2.20,<3
 lxml
 tablib
+scipy


### PR DESCRIPTION
This pull request adds confirmation tokens that can be used for shallow integration with external crowd-sourcing apps like Toloka. A task confirmation token (UUID4) is displayed on the user's dashboard if the user have completed all assigned tasks. If the user passed the quality control, the valid confirmation token is shown, which is the same as the one exported via `init_campaign.py --task-confirmation-tokens`; otherwise an invalid confirmation token is shown, i.e. it is different than the token generated via `init_campaign.py`.

Changes proposed in the pull request:
- Valid or invalid confirmation tokens are generated based on passing or failing the quality control.
- The quality control method is extracted from the campaign status check.
- A confirmation token is shown on the dashboard after all tasks assigned to the user have been finished (see the screenshot below).
- Added option `--task-confirmation-tokens` to `init_campaign.py` for exporting users' valid confirmation tokens.

Feel free to update thresholds for passing the quality control as the current values are quite arbitrary.

![appraise-confirmation-token](https://user-images.githubusercontent.com/1850195/122886909-47bb0400-d338-11eb-821d-514989f63aa5.png)

@AppraiseDev/core-team
