### PR TITLE
Changed ID generation for radio boxes to using `forloop.counter`

### DIFF
--- a/EvalView/templates/EvalView/data-assessment.html
+++ b/EvalView/templates/EvalView/data-assessment.html
@@ -184,12 +184,12 @@ function update_score() {
     <div class="item-box item-{% cycle 'odd' 'even' %} quotelike">
         <div class="row">
             <div class="col-sm-6">
-                <span title="Source sentence #{{ loop.index|add:"1" }}">
+                <span title="Source sentence #{{ forloop.counter }}">
                     <p>{{ source_text|safe }}</p>
                 </span>
             </div>
             <div class="col-sm-6">
-                <span title="Target sentence #{{ loop.index|add:"1" }}">
+                <span title="Target sentence #{{ forloop.counter }}">
                     <p>{{ target_text|safe }}</p>
                 </span>
             </div>

--- a/EvalView/templates/EvalView/data-assessment.html
+++ b/EvalView/templates/EvalView/data-assessment.html
@@ -80,7 +80,7 @@ function reset_form() {
     $('#slider').slider('option', 'value', 0);
     $('input[name="score"]').val(-1);
     // reset rank
-    $('input[name="rank"]').attr('checked',false);
+    $('input[name="rank"]').prop('checked',false);
 }
 
 function validate_form() {

--- a/EvalView/templates/EvalView/data-assessment.html
+++ b/EvalView/templates/EvalView/data-assessment.html
@@ -245,7 +245,7 @@ function update_score() {
             <div class="col-sm-3">
                 <p>
                 <label class="radio-inline">
-                    <input type="radio" name="rank" id="radio-{{ loop.index }}" value="{{ rank_value }}">
+                    <input type="radio" name="rank" id="radio-{{ forloop.counter }}" value="{{ rank_value }}">
                     <span class="radio-label">{{ rank_label }}</span>
                 </label>
                 </p>


### PR DESCRIPTION
Instead of `loop.index`. This fixes issue #29.

Fixes #29 .

Changes proposed in the pull request:

- Change from `loop.index` to `forloop.counter` which is what Django templates expect.

@AppraiseDev/core-team
