### PR TITLE
Escape source and target texts in data tasks

### DIFF
--- a/EvalView/templates/EvalView/data-assessment.html
+++ b/EvalView/templates/EvalView/data-assessment.html
@@ -185,12 +185,12 @@ function update_score() {
         <div class="row">
             <div class="col-sm-6">
                 <span title="Source sentence #{{ loop.index|add:"1" }}">
-                    <p>{{ source_text|safe }}</p>
+                    <p>{{ source_text|escape }}</p>
                 </span>
             </div>
             <div class="col-sm-6">
                 <span title="Target sentence #{{ loop.index|add:"1" }}">
-                    <p>{{ target_text|safe }}</p>
+                    <p>{{ target_text|escape }}</p>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
Fixes a bug: some HTML tags included in the source or target texts (e.g. `</form>`) can block the submission button so that it's impossible to finish the task. Thanks for @cfedermann for reporting this issue.

Changes proposed in the pull request:
- Replacing `|safe` with `|escape`.

@AppraiseDev/core-team
