### PR TITLE
Fix incorrect function name in UpdateEvalDataModels

### DIFF
--- a/EvalData/management/commands/UpdateEvalDataModels.py
+++ b/EvalData/management/commands/UpdateEvalDataModels.py
@@ -85,7 +85,7 @@ class Command(BaseCommand):
         pass
 
     def handle(self, *args, **options):
-        _update_campaign_models(self.stdout)
+        _update_eval_data_models(self.stdout)
 
 
 def _update_eval_data_models(stdout):

--- a/RegressionTests/README.md
+++ b/RegressionTests/README.md
@@ -17,7 +17,7 @@ Then run:
 To run only tests from a specific subdirectory, provide a path to it as the
 argument, for example:
 
-    bash RegressionTests/run.sh RegressionTests/test/examples
+    bash RegressionTests/run.sh RegressionTests/tests/examples
 
 An example output looks like this:
 


### PR DESCRIPTION
Fixes a silly bug which makes `UpdateEvalDataModels` crashing.

Changes proposed in the pull request:
- Fixed the function name.
- Fixed a path in `RegressionTests/README.md`

@AppraiseDev/core-team
