### PR TITLE
Add a feature to accept both zipped or non-zipped json batches (StartNewCampaign.py)

### DIFF
--- a/Campaign/management/commands/StartNewCampaign.py
+++ b/Campaign/management/commands/StartNewCampaign.py
@@ -3,7 +3,6 @@ Appraise evaluation framework
 
 See LICENSE for usage details
 """
-from io import StringIO
 from datetime import datetime
 from os import path
 from zipfile import is_zipfile


### PR DESCRIPTION
Changes proposed in the pull request:

- Allow users to upload batches in a plain and/or zipped json file format. 

@AppraiseDev/core-team
