### PR TITLE
Implement completion status on team pages in the admin panel

### DIFF
--- a/Campaign/management/commands/init_campaign.py
+++ b/Campaign/management/commands/init_campaign.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         # By default, we only include activated tasks into agenda creation.
         # Compute Boolean flag based on negation of --include-completed state.
         only_activated = not options['include_completed']
-        confirmation_tokens = options['task_confirmation_tokens']
+        confirmation_tokens = options.get('task_confirmation_tokens', False)
 
         # Initialise campaign based on manifest data
         _init_campaign(

--- a/Campaign/utils.py
+++ b/Campaign/utils.py
@@ -16,28 +16,12 @@ from Dashboard.models import (
     validate_language_code,
 )
 from EvalData.models import (
-    DataAssessmentTask,
-    DirectAssessmentTask,
-    DirectAssessmentContextTask,
-    DirectAssessmentDocumentTask,
-    MultiModalAssessmentTask,
-    PairwiseAssessmentTask,
+    CAMPAIGN_TASK_TYPES,
     Market,
     Metadata,
     ObjectID,
     TaskAgenda,
 )
-
-# Map convinient task type names into their corresponding task classes
-CAMPAIGN_TASK_TYPES = {
-    'Data': DataAssessmentTask,
-    'Direct': DirectAssessmentTask,
-    'DocLevelDA': DirectAssessmentContextTask,
-    'Document': DirectAssessmentDocumentTask,
-    'MultiModal': MultiModalAssessmentTask,
-    'Pairwise': PairwiseAssessmentTask,
-}
-
 
 def _create_uniform_task_map(annotators, tasks, redudancy):
     """

--- a/Dashboard/utils.py
+++ b/Dashboard/utils.py
@@ -18,16 +18,8 @@ from EvalData.models import (
     DirectAssessmentDocumentResult,
     MultiModalAssessmentResult,
     PairwiseAssessmentResult,
+    RESULT_TYPES
 )
-
-RESULT_TYPES = {
-    DataAssessmentResult,
-    DirectAssessmentResult,
-    DirectAssessmentContextResult,
-    DirectAssessmentDocumentResult,
-    MultiModalAssessmentResult,
-    PairwiseAssessmentResult,
-}
 
 # Maximum allowed p-value for the Wilcoxon rank-sum test
 MAX_WILCOXON_PVALUE = 0.010

--- a/Dashboard/views.py
+++ b/Dashboard/views.py
@@ -19,68 +19,17 @@ from Appraise.utils import _get_logger
 from Dashboard.models import UserInviteToken, LANGUAGE_CODES_AND_NAMES
 from Dashboard.utils import generate_confirmation_token
 from EvalData.models import (
-    DataAssessmentTask,
-    DataAssessmentResult,
     DirectAssessmentTask,
-    DirectAssessmentResult,
-    DirectAssessmentContextTask,
-    DirectAssessmentContextResult,
-    DirectAssessmentDocumentTask,
-    DirectAssessmentDocumentResult,
-    MultiModalAssessmentTask,
-    MultiModalAssessmentResult,
-    PairwiseAssessmentTask,
-    PairwiseAssessmentResult,
     TaskAgenda,
-)
-
-# TODO: move task definition to models so that they can be used
-# elsewhere in the codebase
-
-TASK_DEFINITIONS = (
-    (
-        'direct',
-        DirectAssessmentTask,
-        DirectAssessmentResult,
-        'direct-assessment',
-    ),
-    (
-        'context',
-        DirectAssessmentContextTask,
-        DirectAssessmentContextResult,
-        'direct-assessment-context',
-    ),
-    (
-        'document',
-        DirectAssessmentDocumentTask,
-        DirectAssessmentDocumentResult,
-        'direct-assessment-document',
-    ),
-    (
-        'multimodal',
-        MultiModalAssessmentTask,
-        MultiModalAssessmentResult,
-        'multimodal-assessment',
-    ),
-    (
-        'pairwise',
-        PairwiseAssessmentTask,
-        PairwiseAssessmentResult,
-        'pairwise-assessment',
-    ),
-    (
-        'data',
-        DataAssessmentTask,
-        DataAssessmentResult,
-        'data-assessment',
-    ),
+    TASK_DEFINITIONS,
 )
 
 TASK_TYPES   = tuple([tup[1] for tup in TASK_DEFINITIONS])
 TASK_RESULTS = tuple([tup[2] for tup in TASK_DEFINITIONS])
+
 # TODO: task names should be stored in task classes as an attribute
-TASK_NAMES   = {tup[1]:tup[0] for tup in TASK_DEFINITIONS}
-TASK_URLS    = {tup[0]:tup[3] for tup in TASK_DEFINITIONS}
+TASK_NAMES   = {tup[1]:tup[0].lower() for tup in TASK_DEFINITIONS}
+TASK_URLS    = {tup[0].lower():tup[3] for tup in TASK_DEFINITIONS}
 
 
 from deprecated import add_deprecated_method

--- a/EvalData/models/__init__.py
+++ b/EvalData/models/__init__.py
@@ -11,3 +11,49 @@ from .direct_assessment_document import *
 from .multi_modal_assessment import *
 from .pairwise_assessment import *
 from .task_agenda import *
+
+# Task definitions: user-friendly name, task class, task result class, URL name
+TASK_DEFINITIONS = (
+    (
+        'Direct',
+        DirectAssessmentTask,
+        DirectAssessmentResult,
+        'direct-assessment',
+    ),
+    (
+        'DocLevelDA',
+        DirectAssessmentContextTask,
+        DirectAssessmentContextResult,
+        'direct-assessment-context',
+    ),
+    (
+        'Document',
+        DirectAssessmentDocumentTask,
+        DirectAssessmentDocumentResult,
+        'direct-assessment-document',
+    ),
+    (
+        'MultiModal',
+        MultiModalAssessmentTask,
+        MultiModalAssessmentResult,
+        'multimodal-assessment',
+    ),
+    (
+        'Pairwise',
+        PairwiseAssessmentTask,
+        PairwiseAssessmentResult,
+        'pairwise-assessment',
+    ),
+    (
+        'Data',
+        DataAssessmentTask,
+        DataAssessmentResult,
+        'data-assessment',
+    ),
+)
+
+# Map convenient task type names into their corresponding task classes
+CAMPAIGN_TASK_TYPES = {tup[0]:tup[1] for tup in TASK_DEFINITIONS}
+
+# List of task result types
+RESULT_TYPES = tuple([tup[2] for tup in TASK_DEFINITIONS])


### PR DESCRIPTION
Displays an estimated completion status in percentages for each campaign (i.e. a team) on the team page in the admin panel. It's the `COMPLETION STATUS` column under `admin/Campaign/campaignteam/`

Changes proposed in this pull request:
- Display completion status as the number of completed tasks / required annotations
- Small clean up: moving the global list of task and task type definitions to `EvalData/models`

@AppraiseDev/core-team
