### PR TITLE
Escape source and target texts in direct and pairwise tasks

### DIFF
--- a/EvalView/templates/EvalView/direct-assessment.html
+++ b/EvalView/templates/EvalView/direct-assessment.html
@@ -35,7 +35,7 @@ $(document).ready(function() {
   var $a = $('#id_candidate_text').attr('data-pseudo-content');
   $('#id_candidate_text').attr('data-pseudo-content', $a.rot13());
   alert($a);
-  
+
   // Increment the idle time counter every second.
   //var idleInterval = setInterval(timerIncrement, 1000);
 
@@ -134,7 +134,7 @@ function update_score()
 <div class="row">
 <div class="col-sm-12">
 <blockquote>
-<p><strong>{{reference_text|safe}}</strong></p>
+<p><strong>{{reference_text|escape}}</strong></p>
 <small>{{reference_label}}</small>
 </blockquote>
 </div>
@@ -151,7 +151,7 @@ function update_score()
 <div class="col-sm-12">
 <blockquote>
 <!--<p id="id_candidate_text" data-pseudo-content="{{candidate_text|safe}}"></p>-->
-<p><strong>{{candidate_text|safe}}</strong></p>
+<p><strong>{{candidate_text|escape}}</strong></p>
 <small>{{candidate_label}}</small>
 </blockquote>
 </div>

--- a/EvalView/templates/EvalView/pairwise-assessment.html
+++ b/EvalView/templates/EvalView/pairwise-assessment.html
@@ -160,7 +160,7 @@ function match_sliders()
     {% endif %}
     </div>
 
-    <p><strong>{{reference_text|safe}}</strong></p>
+    <p><strong>{{reference_text|escape}}</strong></p>
     <p class="quotelike-author" id="reference-label">{{reference_label}}</p>
 
     <div class="context-sentences" style="display: none">
@@ -188,7 +188,7 @@ function match_sliders()
 
 <div class="row quotelike">
     <div class="col-sm-12">
-        <p class="candidate-text"><strong>{{candidate_text|safe}}</strong></p>
+        <p class="candidate-text"><strong>{{candidate_text|escape}}</strong></p>
     </div>
     <div class="col-sm-12">
         <div id="slider" class="slider"></div>
@@ -211,7 +211,7 @@ function match_sliders()
 
 <div class="row quotelike">
     <div class="col-sm-12">
-        <p class="candidate-text"><strong>{{candidate2_text|safe}}</strong></p>
+        <p class="candidate-text"><strong>{{candidate2_text|escape}}</strong></p>
     </div>
     <div class="col-sm-12">
         <div id="slider2" class="slider"></div>


### PR DESCRIPTION
Changes proposed in the pull request:

- use |escape instead of |safe to avoid crashing item view page with tag-like tokens such as <title> in the source and target texts in the direct and pairwise DA tasks 
![crashed-page-example](https://user-images.githubusercontent.com/2372235/150604213-d3f8c96a-9e45-44ef-89b7-0403607f573c.png)

