### PR TITLE
switch "escape" back to "safe" for candidate texts

### DIFF
--- a/EvalView/templates/EvalView/pairwise-assessment.html
+++ b/EvalView/templates/EvalView/pairwise-assessment.html
@@ -188,7 +188,7 @@ function match_sliders()
 
 <div class="row quotelike">
     <div class="col-sm-12">
-        <p class="candidate-text"><strong>{{candidate_text|escape}}</strong></p>
+        <p class="candidate-text"><strong>{{candidate_text|safe}}</strong></p>
     </div>
     <div class="col-sm-12">
         <div id="slider" class="slider"></div>
@@ -211,7 +211,7 @@ function match_sliders()
 
 <div class="row quotelike">
     <div class="col-sm-12">
-        <p class="candidate-text"><strong>{{candidate2_text|escape}}</strong></p>
+        <p class="candidate-text"><strong>{{candidate2_text|safe}}</strong></p>
     </div>
     <div class="col-sm-12">
         <div id="slider2" class="slider"></div>


### PR DESCRIPTION
pairwise uses markups for highlighting diffs between the two target texts.
"escape" creates target texts with a lot of tags and disable highlighting
![contrastive_highlights_disabled_due_to_escape](https://user-images.githubusercontent.com/2372235/151029372-79a9f24a-0547-4723-8099-56fdfc039985.png)

