### PR TITLE
Bump Django to 3.2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.9.3
-Django==3.2.12
+Django==3.2.13
 django-stubs==1.8.0
 lxml==4.6.5
 psycopg2-binary==2.9.1


### PR DESCRIPTION
Fixes recent fails in Safety checks, for example: https://github.com/AppraiseDev/Appraise/runs/6725289591?check_suite_focus=true

@AppraiseDev/core-team
