### PR TITLE
Support videos in document-level DA tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ appraise.log
 *.sw[po]
 
 .venv
-db.sqlite3
+venv
+db.sqlite3*

--- a/Dashboard/models.py
+++ b/Dashboard/models.py
@@ -208,6 +208,7 @@ LANGUAGE_CODES_AND_NAMES = {
     'chv': 'Chuvash (Чӑвашла)',
     'lin': 'Lingala (Lingála)',
     'lug': 'Luganda (Oluganda)',
+    'sgg': 'Swiss-German Sign Language (Deutschschweizer Gebärdensprache (DSGS))',
 }
 
 # Ensure that all languages have a corresponding group.

--- a/Dashboard/models.py
+++ b/Dashboard/models.py
@@ -211,6 +211,9 @@ LANGUAGE_CODES_AND_NAMES = {
     'sgg': 'Swiss-German Sign Language (Deutschschweizer Gebärdensprache (DSGS))',
 }
 
+# All sign language codes
+SIGN_LANGUAGE_CODES = set([LANGUAGE_CODES_AND_NAMES['sgg']])
+
 # Ensure that all languages have a corresponding group.
 try:
     for code in LANGUAGE_CODES_AND_NAMES:

--- a/EvalView/templates/EvalView/direct-assessment-document.html
+++ b/EvalView/templates/EvalView/direct-assessment-document.html
@@ -36,6 +36,9 @@
 .toggleable { display:none; }
 .toggleable.active { display:block; }
 
+.toggleable-reverse { display:block; }
+.active .toggleable-reverse { display:none; }
+
 .target-box .row { padding-top:0; }
 .target-box.active { display:block; }
 
@@ -332,7 +335,7 @@ function submit_form(e) {
 
                 _show_error_box(item_box,
                     'An unrecognized error has occured. ' +
-                    'Please reload the page or try again in a moment.' +
+                    'Please reload the page or try again in a moment. ' +
                     'Also, make sure you use a relatively modern browser.'
                 );
             },
@@ -511,7 +514,13 @@ function _show_error_box(item_box, msg) {
                 <div class="col-sm-6">
                     <span class="pull-left source-btn-toggle glyphicon glyphicon-menu-down"></span>
                     <span title="Source sentence #{{ item.itemID|add:"1" }}">
+                        {% if source_item_type == 'video' %}
+                        <iframe class="toggleable" width="auto" height="auto" src="{{ item.sourceText }}"
+                                frameborder="0" allowfullscreen></iframe>
+                        <p class="toggleable-reverse"><i>&lt;Video is hidden. Click to expand.&gt;</i></p>
+                        {% else %}
                         <p>{{ item.sourceText }}</p>
+                        {% endif %}
                         <!--
                             <small class="">- {{ reference_label }}</small>
                         -->
@@ -519,7 +528,13 @@ function _show_error_box(item_box, msg) {
                 </div>
                 <div class="col-sm-5">
                     <span title="Candidate translation of source sentence #{{ item.itemID|add:"1" }}">
+                        {% if target_item_type == 'video' %}
+                        <iframe class="toggleable" width="auto" height="auto" src="{{ item.targetText }}"
+                                frameborder="0" allowfullscreen></iframe>
+                        <p class="toggleable-reverse"><i>&lt;Video is hidden. Click to expand.&gt;</i></p>
+                        {% else %}
                         <p><strong>{{item.targetText|safe}}</strong></p>
+                        {% endif %}
                     </span>
                 </div>
                 <div class="col-sm-1">

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -906,10 +906,10 @@ def direct_assessment_document(request, code=None, campaign_name=None):
             'not so strict.</li>',
         ]
         if current_task.marketSourceLanguageCode() == "aeb":
-            priming_question_texts[
-                -1
-            ] += '<li>The original source is Tunisian Arabic speech. ' \
-               + 'There may be some variation in the transcription.</li>'
+            priming_question_texts[-1] += (
+                '<li>The original source is Tunisian Arabic speech. '
+                + 'There may be some variation in the transcription.</li>'
+            )
         priming_question_texts[-1] += '</ul>'
 
     # Special instructions for IWSLT 2022 isometric task
@@ -919,12 +919,12 @@ def direct_assessment_document(request, code=None, campaign_name=None):
             '<ul>'
             '<li>The source texts come from transcribed video content published on YouTube.</li>'
             '<li>Transcribed sentences have been split into segments based on pauses in the audio. '
-                'It may happen that a single source sentence is split into multiple segments.</li>'
+            'It may happen that a single source sentence is split into multiple segments.</li>'
             '<li>Please score each segment (including very short segments) individually with regard to '
-                'the source segment and the surrounding context.</li>'
+            'the source segment and the surrounding context.</li>'
             '<li>Take into account both grammar and meaning when scoring the segments.</li>'
             '<li>Please pay attention to issues like repeated or new content in the candidate '
-                'translation, which is not present in the source text.</li>'
+            'translation, which is not present in the source text.</li>'
             '</ul>',
         ]
 

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -14,6 +14,7 @@ from django.utils.timezone import utc
 from Appraise.settings import BASE_CONTEXT
 from Appraise.utils import _get_logger
 from Campaign.models import Campaign
+from Dashboard.models import SIGN_LANGUAGE_CODES
 from EvalData.models import DataAssessmentResult
 from EvalData.models import DataAssessmentTask
 from EvalData.models import DirectAssessmentContextResult
@@ -801,6 +802,10 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         LOGGER.info('No current item detected, redirecting to dashboard')
         return redirect('dashboard')
 
+    # By default, source and target items are text segments
+    source_item_type = 'text'
+    target_item_type = 'text'
+
     # Get item scores from the latest corresponding results
     block_scores = []
     _prev_item = None
@@ -865,11 +870,24 @@ def direct_assessment_document(request, code=None, campaign_name=None):
     ]
 
     speech_translation = 'speechtranslation' in campaign_opts
+    sign_translation = 'signlt' in campaign_opts
 
     use_sqm = 'sqm' in campaign_opts
     if use_sqm:
         priming_question_texts = priming_question_texts[:1]
         document_question_texts = document_question_texts[:1]
+
+    if 'wmt22signlt' in campaign_opts:
+        sign_translation = True
+
+    if sign_translation:
+        # For sign languages, source or target segments are videos
+        if source_language in SIGN_LANGUAGE_CODES:
+            source_item_type = 'video'
+            reference_label = 'Source video'
+        if target_language in SIGN_LANGUAGE_CODES:
+            target_item_type = 'video'
+            candidate_label = 'Candidate translation (video)'
 
     # Special instructions for IWSLT 2022 dialect task
     if 'iwslt2022dialectsrc' in campaign_opts:
@@ -890,7 +908,8 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         if current_task.marketSourceLanguageCode() == "aeb":
             priming_question_texts[
                 -1
-            ] += '<li>The original source is Tunisian Arabic speech. There may be some variation in the transcription.</li>'
+            ] += '<li>The original source is Tunisian Arabic speech. ' \
+               + 'There may be some variation in the transcription.</li>'
         priming_question_texts[-1] += '</ul>'
 
     # Special instructions for IWSLT 2022 isometric task
@@ -899,10 +918,13 @@ def direct_assessment_document(request, code=None, campaign_name=None):
             'Please take into consideration the following aspects when assessing the translation quality:',
             '<ul>'
             '<li>The source texts come from transcribed video content published on YouTube.</li>'
-            '<li>Transcribed sentences have been split into segments based on pauses in the audio. It may happen that a single source sentence is split into multiple segments.</li>'
-            '<li>Please score each segment (including very short segments) individually with regard to the source segment and the surrounding context.</li>'
+            '<li>Transcribed sentences have been split into segments based on pauses in the audio. '
+                'It may happen that a single source sentence is split into multiple segments.</li>'
+            '<li>Please score each segment (including very short segments) individually with regard to '
+                'the source segment and the surrounding context.</li>'
             '<li>Take into account both grammar and meaning when scoring the segments.</li>'
-            '<li>Please pay attention to issues like repeated or new content in the candidate translation, which is not present in the source text.</li>'
+            '<li>Please pay attention to issues like repeated or new content in the candidate '
+                'translation, which is not present in the source text.</li>'
             '</ul>',
         ]
 
@@ -918,6 +940,8 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         'items_left_in_block': len(block_items) - completed_items_in_block,
         'source_language': source_language,
         'target_language': target_language,
+        'source_item_type': source_item_type,
+        'target_item_type': target_item_type,
         'debug_times': (t2 - t1, t3 - t2, t4 - t3, t4 - t1),
         'template_debug': 'debug' in request.GET,
         'campaign': campaign.campaignName,
@@ -925,6 +949,7 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         'trusted_user': current_task.is_trusted_user(request.user),
         'sqm': use_sqm,
         'speech': speech_translation,
+        'signlt': sign_translation,
     }
 
     if ajax:

--- a/Examples/SignLT/README.md
+++ b/Examples/SignLT/README.md
@@ -1,0 +1,12 @@
+# Appraise Evaluation System
+
+An example campaign featuring document-level DA tasks for sign languages:
+
+    python manage.py StartNewCampaign Examples/SignLT/manifest.json \
+        --batches-json Examples/SignLT/batches.sgg-deu.json Examples/SignLT/batches.deu-sgg.json \
+        --csv-output Examples/SignLT/output.csv
+
+    # See Examples/SignLT/outputs.csv for a SSO login for the annotator account
+    # Collect some annotations, then export annotation scores...
+
+    python manage.py ExportSystemScoresToCSV example11signlt

--- a/Examples/SignLT/manifest.json
+++ b/Examples/SignLT/manifest.json
@@ -1,0 +1,15 @@
+{
+    "CAMPAIGN_URL": "http://127.0.0.1:8000/dashboard/sso/",
+    "CAMPAIGN_NAME": "example11signlt",
+    "CAMPAIGN_KEY": "c11",
+    "CAMPAIGN_NO": 11,
+    "REDUNDANCY": 1,
+
+    "TASKS_TO_ANNOTATORS": [
+        ["sgg", "deu", "uniform",  1, 1],
+        ["deu", "sgg", "uniform",  1, 1]
+    ],
+
+    "TASK_TYPE": "Document",
+    "TASK_OPTIONS": "SQM;WMT22SignLT"
+}


### PR DESCRIPTION
Appraise will host sign language translation evaluation.

Changes proposed in the pull request:
- Added language code for DSGS
- Added new keyword to the campaign options: "WMT22SignLT", which triggers interpreting source or target segments as videos
- Added a new example (note that the `batches.json` will be added once we have confirmation that we can use sample videos)

@AppraiseDev/core-team
