### PR TITLE
Monolingual document-level tasks

### DIFF
--- a/EvalView/templates/EvalView/_sqm_instructions.html
+++ b/EvalView/templates/EvalView/_sqm_instructions.html
@@ -14,6 +14,12 @@
       <li><strong>4: Most meaning preserved and acceptable motion</strong>: The translation retains most of the meaning of the source. It may have some minor mistakes or contextual inconsistencies. Motion may lack naturalness or expressiveness.</li>
       <li><strong>6: Perfect meaning and motion</strong>: The meaning of the translation is completely consistent with the source and the surrounding context. Motion is natural and expressive.</li>
 
+      {% elif mono %}
+      <li><strong>0: Nonsense/No meaning</strong>: Nearly all information and discourse coherence is lost. Grammar is irrelevant.</li>
+      <li><strong>2: Some discourse preserved</strong>: The text preserves some of the discourse coherence. The narrative is hard to follow due to fundamental errors. Grammar may be poor.</li>
+      <li><strong>4: Most discourse preserved and few grammar mistakes</strong>: The text retains most of the discourse coherence. It may have some grammar mistakes or stylistic contextual inconsistencies.</li>
+      <li><strong>6: Perfect discourse and grammar</strong>: The text is completely consistent with the surrounding context and the discourse coherence is perfect. The grammar is also correct.</li>
+
       {% else %}
       <li><strong>0: Nonsense/No meaning preserved</strong>: Nearly all information is lost between the translation and source. Grammar is irrelevant.</li>
       <li><strong>2: Some meaning preserved</strong>: The translation preserves some of the meaning of the source but misses significant parts. The narrative is hard to follow due to fundamental errors. Grammar may be poor.</li>

--- a/EvalView/templates/EvalView/_sqm_slider.html
+++ b/EvalView/templates/EvalView/_sqm_slider.html
@@ -25,6 +25,11 @@
       <td class="sqm-label col-xs-4" style="vertical-align:top;text-align:center;">2: Some meaning preserved</td>
       <td class="sqm-label col-xs-4" style="vertical-align:top;text-align:center;">4: Most meaning preserved and acceptable motion</td>
       <td class="sqm-label sqm-label-last col-xs-2" style="vertical-align:top;text-align:right;padding-right:0;">6: Perfect meaning and motion</td>
+      {% elif mono %}
+      <td class="sqm-label sqm-label-first col-xs-2" style="vertical-align:top;text-align:left;padding-left:0;">0: Nonsense/ No meaning</td>
+      <td class="sqm-label col-xs-4" style="vertical-align:top;text-align:center;">2: Some discourse preserved</td>
+      <td class="sqm-label col-xs-4" style="vertical-align:top;text-align:center;">4: Most discourse preserved and few grammar mistakes</td>
+      <td class="sqm-label sqm-label-last col-xs-2" style="vertical-align:top;text-align:right;padding-right:0;">6: Perfect discourse and grammar</td>
       {% else %}
       <td class="sqm-label sqm-label-first col-xs-2" style="vertical-align:top;text-align:left;padding-left:0;">0: Nonsense/ No meaning preserved</td>
       <td class="sqm-label col-xs-4" style="vertical-align:top;text-align:center;">2: Some meaning preserved</td>

--- a/EvalView/templates/EvalView/direct-assessment-document.html
+++ b/EvalView/templates/EvalView/direct-assessment-document.html
@@ -463,7 +463,7 @@ function _show_error_box(item_box, msg) {
             <p>{{text|safe}}</p>
             {% endfor %}
             {% if sqm %}
-              {% with speech=speech signlt=signlt %}
+              {% with speech=speech signlt=signlt mono=monolingual %}
               {% include 'EvalView/_sqm_instructions.html' %}
               {% endwith %}
             {% endif %}
@@ -497,6 +497,7 @@ function _show_error_box(item_box, msg) {
 <div class="item-box item-odd item-static-content pseudoquotelike">
         <div class="source-box">
             <div class="row">
+                {% if not monolingual %}
                 <div class="col-sm-6">
                     <span title="Source static context">
                         <p>{{ item.sourceContextLeft|linebreaks }}</p>
@@ -513,6 +514,16 @@ function _show_error_box(item_box, msg) {
                         {% endif %}
                     </span>
                 </div>
+                {% else %}
+                <div class="col-sm-11">
+                    <span title="Static context">
+                        <p>{{ item.targetContextLeft|linebreaks }}</p>
+                        {% if item.targetContextLeft %}
+                        <small class="segment-label">- Additional context</small>
+                        {% endif %}
+                    </span>
+                </div>
+                {% endif %}
             </div>
         </div>
 </div>
@@ -543,6 +554,7 @@ function _show_error_box(item_box, msg) {
 
         <div class="source-box source-box-hoverable">
             <div class="row">
+                {% if not monolingual %}
                 <div class="col-sm-6">
                     <span class="pull-left source-btn-toggle glyphicon glyphicon-menu-down"></span>
                     <span title="Source sentence #{{ item.itemID|add:"1" }}">
@@ -553,12 +565,13 @@ function _show_error_box(item_box, msg) {
                         {% else %}
                         <p>{{ item.sourceText }}</p>
                         {% endif %}
-                        <!--
-                            <small class="">- {{ reference_label }}</small>
-                        -->
                     </span>
                 </div>
-                <div class="col-sm-5">
+                {% endif %}
+                <div class="{% if not monolingual %}col-sm-5{% else %}col-sm-11{% endif %}">
+                  {% if monolingual %}
+                    <span class="pull-left source-btn-toggle glyphicon glyphicon-menu-down"></span>
+                  {% endif %}
                     <span title="Candidate translation of source sentence #{{ item.itemID|add:"1" }}">
                         {% if target_item_type == 'video' %}
                         <iframe class="toggleable" width="auto" height="auto" src="{{ item.targetText }}"
@@ -579,7 +592,7 @@ function _show_error_box(item_box, msg) {
         <div class="target-box toggleable" >
             <div class="row">
             {% if sqm %}
-                {% with sliderid=item.itemID speech=speech signlt=signlt %}
+                {% with sliderid=item.itemID speech=speech signlt=signlt mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}
@@ -618,7 +631,9 @@ function _show_error_box(item_box, msg) {
                     <p>{{text|safe}}</p>
                     {% endfor %}
                     {% if sqm %}
-                    {% include 'EvalView/_sqm_instructions.html' %}
+                      {% with speech=speech signlt=signlt mono=monolingual %}
+                      {% include 'EvalView/_sqm_instructions.html' %}
+                      {% endwith %}
                     {% endif %}
                 </div>
             </div>
@@ -627,7 +642,7 @@ function _show_error_box(item_box, msg) {
         <div class="target-box document-box quotelike">
             <div class="row">
             {% if sqm %}
-                {% with sliderid=item.itemID speech=speech %}
+                {% with sliderid=item.itemID speech=speech mono=monolingual%}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}

--- a/EvalView/templates/EvalView/direct-assessment-document.html
+++ b/EvalView/templates/EvalView/direct-assessment-document.html
@@ -568,6 +568,7 @@ function _show_error_box(item_box, msg) {
                     </span>
                 </div>
                 {% endif %}
+
                 <div class="{% if not monolingual %}col-sm-5{% else %}col-sm-11{% endif %}">
                   {% if monolingual %}
                     <span class="pull-left source-btn-toggle glyphicon glyphicon-menu-down"></span>

--- a/EvalView/templates/EvalView/pairwise-assessment-document.html
+++ b/EvalView/templates/EvalView/pairwise-assessment-document.html
@@ -498,7 +498,9 @@ function _show_error_box(item_box, msg) {
             <p>{{text|safe}}</p>
             {% endfor %}
             {% if sqm %}
+            {% with mono=monolingual %}
             {% include 'EvalView/_sqm_instructions.html' %}
+            {% endwith %}
             {% endif %}
         </div>
     </div>
@@ -525,6 +527,7 @@ function _show_error_box(item_box, msg) {
 <div class="item-box item-odd item-static-content pseudoquotelike">
         <div class="source-box">
             <div class="row">
+                {% if not monolingual %}
                 <div class="col-sm-3">
                     <span title="Source static context">
                         <p>{{ item.contextLeft|linebreaks }}</p>
@@ -549,6 +552,24 @@ function _show_error_box(item_box, msg) {
                         {% endif %}
                     </span>
                 </div>
+                {% else %}
+                <div class="col-sm-6">
+                    <span title="Static context of the first document">
+                        <p><strong>{{ item.target1ContextLeft|linebreaks }}</strong></p>
+                        {% if item.target1ContextLeft %}
+                        <small class="segment-label">- Additional context A</small>
+                        {% endif %}
+                    </span>
+                </div>
+                <div class="col-sm-6">
+                    <span title="Static context of the second translation">
+                        <p><strong>{{ item.target2ContextLeft|linebreaks }}</strong></p>
+                        {% if item.target2ContextLeft %}
+                        <small class="segment-label">- Additional context B</small>
+                        {% endif %}
+                    </span>
+                </div>
+                {% endif %}
             </div>
         </div>
 </div>
@@ -581,20 +602,27 @@ function _show_error_box(item_box, msg) {
 
         <div class="source-box-hoverable">
             <div class="row">
+                {% if not monolingual %}
                 <div class="source-box col-sm-3">
                     <span class="pull-left source-btn-toggle glyphicon glyphicon-menu-down"></span>
                     <span title="Source sentence #{{ item.itemID|add:"1" }}">
                         <p>{{ item.segmentText }}<small class="segment-label">- {{ reference_label }}</small></p>
                     </span>
                 </div>
-                <div class="col-sm-4">
+                {% else %}
+                <div class="source-box col-sm-1">
+                    <span class="pull-left source-btn-toggle glyphicon glyphicon-menu-down"></span>
+                </div>
+                {% endif %}
+
+                <div class="{% if monolingual %}col-sm-5{% else %}col-sm-4{% endif %}">
                     <span title="Candidate translation A of source sentence #{{ item.itemID|add:"1" }}">
                         <p class="source-box candidate-text"><strong>{{scores.candidate1_text|safe}}</strong><small class="segment-label">- {{ candidate1_label }}</small></p>
                     </span>
 
             <div class="row half-slider target-box toggleable">
             {% if sqm %}
-                {% with sliderid=item.itemID slidernum=1 %}
+                {% with sliderid=item.itemID slidernum=1 mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}
@@ -605,14 +633,14 @@ function _show_error_box(item_box, msg) {
             </div>
 
                 </div>
-                <div class="col-sm-4">
+                <div class="{% if monolingual %}col-sm-5{% else %}col-sm-4{% endif %}">
                     <span title="Candidate translation B of source sentence #{{ item.itemID|add:"1" }}">
                         <p class="source-box candidate-text"><strong>{{scores.candidate2_text|safe}}</strong><small class="segment-label">- {{ candidate2_label }}</small></p>
                     </span>
 
             <div class="row half-slider target-box toggleable">
             {% if sqm %}
-                {% with sliderid=item.itemID slidernum=2 %}
+                {% with sliderid=item.itemID slidernum=2 mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}
@@ -642,7 +670,7 @@ function _show_error_box(item_box, msg) {
             <div class="row">
             <div class="col-sm-6">
             {% if sqm %}
-                {% with sliderid=item.itemID %}
+                {% with sliderid=item.itemID mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}
@@ -653,7 +681,7 @@ function _show_error_box(item_box, msg) {
             </div>
             <div class="col-sm-6">
             {% if sqm %}
-                {% with sliderid=item.itemID %}
+                {% with sliderid=item.itemID mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}
@@ -694,7 +722,9 @@ function _show_error_box(item_box, msg) {
                     <p>{{text|safe}}</p>
                     {% endfor %}
                     {% if sqm %}
+                    {% with mono=monolingual %}
                     {% include 'EvalView/_sqm_instructions.html' %}
+                    {% endwith %}
                     {% endif %}
                 </div>
             </div>
@@ -705,7 +735,7 @@ function _show_error_box(item_box, msg) {
             <div class="col-sm-6">
                 <small class="segment-label">{{ candidate1_label }}</small>
             {% if sqm %}
-                {% with sliderid=item.itemID slidernum=1 %}
+                {% with sliderid=item.itemID slidernum=1 mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}
@@ -717,7 +747,7 @@ function _show_error_box(item_box, msg) {
             <div class="col-sm-6">
                 <small class="segment-label">{{ candidate2_label }}</small>
             {% if sqm %}
-                {% with sliderid=item.itemID slidernum=2 %}
+                {% with sliderid=item.itemID slidernum=2 mono=monolingual %}
                 {% include 'EvalView/_sqm_slider.html' %}
                 {% endwith %}
             {% else %}

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -897,6 +897,7 @@ def direct_assessment_document(request, code=None, campaign_name=None):
             'Please score the overall document quality (you can score '
             'the whole document only after scoring all individual sentences first).',
         ]
+        candidate_label = None
 
     if sign_translation:
         # For sign languages, source or target segments are videos
@@ -1992,7 +1993,7 @@ def pairwise_assessment_document(request, code=None, campaign_name=None):
     if monolingual_task:
         source_language = None
         priming_question_texts = [
-            'Below you see multiple documents, each with {0} sentences in {1}. '
+            'Below you see two documents, each with {0} sentences in {1}. '
             'Score each sentence in both documents in their respective document context. '
             'You may revisit already scored sentences and update their scores at any time '
             'by clicking at a source text.'.format(
@@ -2004,6 +2005,8 @@ def pairwise_assessment_document(request, code=None, campaign_name=None):
             'the whole document only after scoring all individual sentences from all '
             'documents first).',
         ]
+        candidate1_label = 'Sentence A'
+        candidate2_label = 'Sentence B'
 
     # A part of context used in responses to both Ajax and standard POST
     # requests

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -868,6 +868,7 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         'in {1} (left column)? '.format(target_language, source_language),
     ]
 
+    monolingual_task = 'monolingual' in campaign_opts
     sign_translation = 'signlt' in campaign_opts
     speech_translation = 'speechtranslation' in campaign_opts
     static_context = 'staticcontext' in campaign_opts
@@ -881,6 +882,21 @@ def direct_assessment_document(request, code=None, campaign_name=None):
     if use_sqm:
         priming_question_texts = priming_question_texts[:1]
         document_question_texts = document_question_texts[:1]
+
+    if monolingual_task:
+        source_language = None
+        priming_question_texts = [
+            'Below you see a document with {0} sentences in {1}. '
+            'Score each candidate sentence translation in the document context. '
+            'You may revisit already scored sentences and update their scores at any time '
+            'by clicking at a source text.'.format(
+                len(block_items) - 1, target_language
+            ),
+        ]
+        document_question_texts = [
+            'Please score the overall document quality (you can score '
+            'the whole document only after scoring all individual sentences first).',
+        ]
 
     if sign_translation:
         # For sign languages, source or target segments are videos
@@ -951,9 +967,11 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         'campaign': campaign.campaignName,
         'datask_id': current_task.id,
         'trusted_user': current_task.is_trusted_user(request.user),
+        # Task variations
         'sqm': use_sqm,
         'speech': speech_translation,
         'signlt': sign_translation,
+        'monolingual': monolingual_task,
         'static_context': static_context,
     }
 

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -887,7 +887,7 @@ def direct_assessment_document(request, code=None, campaign_name=None):
         source_language = None
         priming_question_texts = [
             'Below you see a document with {0} sentences in {1}. '
-            'Score each candidate sentence translation in the document context. '
+            'Score each sentence in the document context. '
             'You may revisit already scored sentences and update their scores at any time '
             'by clicking at a source text.'.format(
                 len(block_items) - 1, target_language
@@ -1981,12 +1981,29 @@ def pairwise_assessment_document(request, code=None, campaign_name=None):
     ]
 
     campaign_opts = (campaign.campaignOptions or "").lower()
+    monolingual_task = 'monolingual' in campaign_opts
     use_sqm = 'sqm' in campaign_opts
     static_context = 'staticcontext' in campaign_opts
 
     if use_sqm:
         priming_question_texts = priming_question_texts[:1]
         document_question_texts = document_question_texts[:1]
+
+    if monolingual_task:
+        source_language = None
+        priming_question_texts = [
+            'Below you see multiple documents, each with {0} sentences in {1}. '
+            'Score each sentence in both documents in their respective document context. '
+            'You may revisit already scored sentences and update their scores at any time '
+            'by clicking at a source text.'.format(
+                len(block_items) - 1, target_language
+            ),
+        ]
+        document_question_texts = [
+            'Please score the overall quality of each document (you can score '
+            'the whole document only after scoring all individual sentences from all '
+            'documents first).',
+        ]
 
     # A part of context used in responses to both Ajax and standard POST
     # requests
@@ -2005,6 +2022,7 @@ def pairwise_assessment_document(request, code=None, campaign_name=None):
         'campaign': campaign.campaignName,
         'datask_id': current_task.id,
         'trusted_user': current_task.is_trusted_user(request.user),
+        'monolingual': monolingual_task,
         'sqm': use_sqm,
         'static_context': static_context,
     }

--- a/Examples/Monolingual/README.md
+++ b/Examples/Monolingual/README.md
@@ -1,0 +1,17 @@
+# Appraise Evaluation System
+
+An example campaign for a monolingual document-level task:
+
+    python manage.py StartNewCampaign Examples/Monolingual/manifest.json \
+        --batches-json Examples/DocumentSQM+Context/batches.json \
+        --csv-output Examples/Monolingual/output.csv
+
+    # See Examples/Monolingual/outputs.csv for a SSO login for the annotator account
+    # Collect some annotations, then export annotation scores...
+
+    python manage.py ExportSystemScoresToCSV example12mono
+
+For a monolingual annotation task, only the target language defined in
+`manifest.json` is used. Note that the `batches.json` file is exactly the same
+as in `Document` and `DocLevelDA` tasks. Only `targetText` and
+`targetContextLeft` are used.

--- a/Examples/Monolingual/manifest.json
+++ b/Examples/Monolingual/manifest.json
@@ -1,0 +1,14 @@
+{
+    "CAMPAIGN_URL": "http://127.0.0.1:8000/dashboard/sso/",
+    "CAMPAIGN_NAME": "example12mono",
+    "CAMPAIGN_KEY": "c12",
+    "CAMPAIGN_NO": 12,
+    "REDUNDANCY": 1,
+
+    "TASKS_TO_ANNOTATORS": [
+        ["eng", "deu", "uniform",  1, 1]
+    ],
+
+    "TASK_TYPE": "Document",
+    "TASK_OPTIONS": "Monolingual;SQM;StaticContext"
+}

--- a/Examples/MonolingualPairwise/README.md
+++ b/Examples/MonolingualPairwise/README.md
@@ -1,0 +1,17 @@
+# Appraise Evaluation System
+
+    python manage.py StartNewCampaign Examples/MonolingualPairwise/manifest.json \
+        --batches-json Examples/PairwiseDocument/batches.json \
+        --csv-output Examples/MonolingualPairwise/output.csv
+
+    # See Examples/PairwiseDocument/outputs.csv for a SSO login for the annotator account
+    # Collect some annotations, then export annotation scores...
+
+    python manage.py ExportSystemScoresToCSV example13monopair
+
+You can use the same batches as for the `PairwiseDocument` task type. Source
+texts and contexts will be ignored.
+
+Note that the static source context (if needed) for this task should be
+included in the key named `segmentContextLeft` in the `batches.json` file. This
+is different than `sourceContextLeft` in the *Document* task type.

--- a/Examples/MonolingualPairwise/manifest.json
+++ b/Examples/MonolingualPairwise/manifest.json
@@ -1,0 +1,14 @@
+{
+    "CAMPAIGN_URL": "http://127.0.0.1:8000/dashboard/sso/",
+    "CAMPAIGN_NAME": "example13monopair",
+    "CAMPAIGN_KEY": "c13",
+    "CAMPAIGN_NO": 13,
+    "REDUNDANCY": 1,
+
+    "TASKS_TO_ANNOTATORS": [
+        ["eng", "deu", "uniform",  1, 1]
+    ],
+
+    "TASK_TYPE": "PairwiseDocument",
+    "TASK_OPTIONS": "Monolingual;SQM;StaticContext"
+}


### PR DESCRIPTION
This PR adds monolingual document-level tasks where the source is not displayed and instructions are different.

Changes proposed in the pull request:
- Added `Monolingual` keyword to campaign options in `Document` and `PairwiseDocument` task types
- Updated SQM instructions (will be revised later)
- Added examples for both tasks

@AppraiseDev/core-team
