### PR TITLE
Update to latest for psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.9.3
 Django>=3.2.14,<4
 django-stubs==1.8.0
 lxml>=4.9.1
-psycopg2-binary==2.9.1
+psycopg2-binary
 git+https://github.com/jazzband/django-debug-toolbar.git#egg=django-debug-toolbar
 tablib==3.0.0
 scipy==1.7.2


### PR DESCRIPTION
Eliminate psycopg version diff as root cause.

@AppraiseDev/core-team
