### PR TITLE
Remove encoding='utf-8' from json.loads for Python 3.9

### DIFF
--- a/Campaign/management/commands/validatecampaigndata.py
+++ b/Campaign/management/commands/validatecampaigndata.py
@@ -54,10 +54,10 @@ def _validate_campaign_data(campaign, stdout=None):
                 ]
                 for batch_json_file in batch_json_files:
                     batch_data = batch_zip.read(batch_json_file).decode('utf-8')
-                    loads(batch_data, encoding='utf-8')
+                    loads(batch_data)
 
             else:
-                loads(str(batch_file.read(), encoding="utf-8"))
+                loads(str(batch_file.read()))
 
             batch.dataValid = True
             batch.save()

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -365,10 +365,10 @@ class DataAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -259,10 +259,10 @@ class DirectAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -303,10 +303,10 @@ class DirectAssessmentContextTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -361,10 +361,10 @@ class DirectAssessmentDocumentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 

--- a/EvalData/models/multi_modal_assessment.py
+++ b/EvalData/models/multi_modal_assessment.py
@@ -292,10 +292,10 @@ class MultiModalAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -266,10 +266,10 @@ class PairwiseAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 

--- a/EvalData/models/pairwise_assessment_document.py
+++ b/EvalData/models/pairwise_assessment_document.py
@@ -389,10 +389,10 @@ class PairwiseAssessmentDocumentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
-            batch_json = loads(str(batch_file.read(), encoding="utf-8"))
+            batch_json = loads(str(batch_file.read()))
 
         from datetime import datetime
 


### PR DESCRIPTION
Fixes an exception when running Appraise with Python 3.9.

Changes proposed in the pull request:
- `json.loads` does not have `encoding` argument since Python 3.9.

@AppraiseDev/core-team
