### PR TITLE
Don't count document-level scores in campaign status pages

### DIFF
--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -16,6 +16,7 @@ from django.http import HttpResponse
 from Appraise.utils import _get_logger
 from Campaign.utils import _get_campaign_instance
 from EvalData.models import DataAssessmentResult
+from EvalData.models import DirectAssessmentDocumentResult
 from EvalData.models import PairwiseAssessmentDocumentResult
 from EvalData.models import PairwiseAssessmentResult
 from EvalData.models import seconds_to_timedelta
@@ -70,6 +71,16 @@ def campaign_status(request, campaign_name, sort_key=2):
                 createdBy=user, completed=True, task__campaign=campaign.id
             )
 
+            # Exclude document scores in document-level tasks, because we want to keep
+            # the numbers reported on the campaign status page consistent across
+            # accounts, which usually include different numbers of document
+            if (
+                result_type is DirectAssessmentDocumentResult
+                or result_type is PairwiseAssessmentDocumentResult
+            ):
+                _data = _data.exclude(item__isCompleteDocument=True)
+
+            # Contrastive tasks use different field names for target segments/scores
             if (
                 result_type is PairwiseAssessmentResult
                 or result_type is PairwiseAssessmentDocumentResult


### PR DESCRIPTION
Fixes displaying different numbers of completed annotations on the campaign status pages for document-level tasks. The reason why we have different numbers is that accounts usually have different number of documents. We can simply not count document-level scores to keep the numbers reported consistent across accounts.

Changes proposed in the pull request:
- Exclude document-level scores from the total annotations displayed on the campaign status pages

@AppraiseDev/core-team
