### PR TITLE
Add Livonian to the ranking computation script

### DIFF
--- a/Campaign/management/commands/ComputeWMT21Results.py
+++ b/Campaign/management/commands/ComputeWMT21Results.py
@@ -31,6 +31,7 @@ LANGUAGE_CODES = {
     'hrv': 'hr',
     'ukr': 'uk',
     'sah': 'sah',
+    'liv': 'liv',
 }
 
 


### PR DESCRIPTION
Adds 'liv' to `ComputWMT21Results.py`.

@AppraiseDev/core-team
