### PR TITLE
Add 'linear' mapping of annotators to tasks

### DIFF
--- a/Campaign/management/commands/init_campaign.py
+++ b/Campaign/management/commands/init_campaign.py
@@ -9,6 +9,7 @@ from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 from tablib import Dataset  # type: ignore
 
+from Campaign.utils import _create_linear_task_map
 from Campaign.utils import _create_uniform_task_map
 from Campaign.utils import _identify_super_users
 from Campaign.utils import _load_campaign_manifest
@@ -218,7 +219,10 @@ def _create_context(manifest_data, stdout=None):
     Parameters:
     - manifest_data:dict[str]->any dictionary containing manifest data;
     """
-    GENERATORS = {'uniform': _create_uniform_task_map}
+    GENERATORS = {
+        'uniform': _create_uniform_task_map,
+        'linear': _create_linear_task_map,
+    }
     ALL_LANGUAGES = []
     ALL_LANGUAGE_CODES = set()
     TASKS_TO_ANNOTATORS = {}

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -2031,9 +2031,15 @@ def pairwise_assessment_document(request, code=None, campaign_name=None):
             'current_item': bool(item.id == current_item.id),
             'score1': result.score1 if result else -1,
             'score2': result.score2 if result else -1,
-            'candidate1_text': _candidate1_text.replace("&lt;eos&gt;", "<code>&lt;eos&gt;</code>"),
-            'candidate2_text': _candidate2_text.replace("&lt;eos&gt;", "<code>&lt;eos&gt;</code>"),
-            'segment_text': escape(item.segmentText).replace("&lt;eos&gt;", "<code>&lt;eos&gt;</code>"),
+            'candidate1_text': _candidate1_text.replace(
+                "&lt;eos&gt;", "<code>&lt;eos&gt;</code>"
+            ),
+            'candidate2_text': _candidate2_text.replace(
+                "&lt;eos&gt;", "<code>&lt;eos&gt;</code>"
+            ),
+            'segment_text': escape(item.segmentText).replace(
+                "&lt;eos&gt;", "<code>&lt;eos&gt;</code>"
+            ),
         }
         block_scores.append(item_scores)
 


### PR DESCRIPTION
Adding "linear" mapping of annotators to tasks for full control of which batches are assigned to whom.

@AppraiseDev/core-team
