### PR TITLE
Add paragraph guidelines to segment-level contrastive tasks

### DIFF
--- a/Dashboard/views.py
+++ b/Dashboard/views.py
@@ -424,6 +424,8 @@ def dashboard(request):
                             languages_map[task_cls][campaign.campaignName].remove(code)
 
             # _type and _languages variables are only for debug
+            _type = None
+            _languages = {}
             for task_cls in campaign_map:
                 if campaign_map[task_cls].exists():
                     _type = TASK_NAMES[task_cls]

--- a/EvalView/templates/EvalView/_guidelines_popup.html
+++ b/EvalView/templates/EvalView/_guidelines_popup.html
@@ -6,9 +6,13 @@
                 <h4 class="modal-title" id="myModalLabel">Important Annotation Guidelines</h4>
             </div>
             <div class="modal-body">
-                {% for text in priming_question_texts %}
-                <p>{{text|safe}}</p>
-                {% endfor %}
+                {% if priming_question_text %}
+                <p>{{priming_question_text|safe}}</p>
+                {% else %}
+                    {% for text in priming_question_texts %}
+                    <p>{{text|safe}}</p>
+                    {% endfor %}
+                {% endif %}
 
                 {% if sqm %}
                 {% with mono=monolingual doclvl=doc_guidelines %}

--- a/EvalView/templates/EvalView/_sqm_instructions.html
+++ b/EvalView/templates/EvalView/_sqm_instructions.html
@@ -54,6 +54,10 @@
     {% else %}
     <p>The numeric labels on the slider are there to help you to adjust the score more precisely, but the slider can be stopped at any position along the track.
     Try to use the full range of the scale when scoring segments and not limit yourself only to the values around the numeric labels.</p>
+
+      {% if doclvl %}
+      <p>Note that sentences in each paragraph can be separated by the <code>&lt;eos&gt;</code> or <code>&lt;br/&gt;</code> tags for convenience and this should not impact your assessment.</p>
+      {% endif %}
     {% endif %}
   </div>
 </div>

--- a/EvalView/templates/EvalView/pairwise-assessment.html
+++ b/EvalView/templates/EvalView/pairwise-assessment.html
@@ -33,6 +33,10 @@ small.padright { padding-right: 20px; }
 .slider-box .slider-grid { font-size:14px; width:100%; color:#777; }
 
 .button-critical-error { margin-top:10px; }
+
+.question-box { margin-bottom:10px; }
+.question-box p { font-size: 120%; margin: 10px 0 20px; font-style: italic; color: #31708f; }
+.question-box li { font-size: 100%; font-style: italic; color: #31708f; }
 </style>
 
 <link rel="stylesheet" href="{% static 'EvalView/css/jquery-ui.css' %}">
@@ -66,6 +70,9 @@ $(document).ready(function() {
 
   // make the first slider active, so that the score can be changed using left/right keys
   $('#slider .ui-slider-handle').focus();
+
+  // Show guidelines in a popup box
+  $('#guidelines-modal').modal('show');
 });
 
 function toggle_context()
@@ -159,6 +166,10 @@ function match_sliders()
   </table>
 </div>
 
+{% if guidelines_popup %}
+    {% include 'EvalView/_guidelines_popup.html' %}
+{% endif %}
+
 <div class="row quotelike">
 <div class="col-sm-12">
     <div class="context-sentences" style="display: none">
@@ -178,7 +189,7 @@ function match_sliders()
 </div>
 </div>
 
-<div class="row">
+<div class="row question-box">
     <div class="col-sm-12">
         <p class="priming-question">{{priming_question_text|safe}}</p>
     </div>
@@ -291,12 +302,16 @@ function match_sliders()
 
 {% if sqm %}
 <br/>
-{% include 'EvalView/_sqm_instructions.html' %}
-{% endif %}
+<div class="question-box">
+  {% with doclvl=doc_guidelines %}
+  {% include 'EvalView/_sqm_instructions.html' %}
+  {% endwith %}
+  {% endif %}
+</div>
 
 {% if source_error %}
 <br/>
-<div class="row">
+<div class="row question-box">
   <div class="col-md-12">
     <b>Serious error(s) in the source text:</b> Please report if a serious error appears
     in the source text making it difficult to understand or translate, for

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -1456,6 +1456,8 @@ def pairwise_assessment(request, code=None, campaign_name=None):
     critical_error = False
     source_error = False
     extra_guidelines = False
+    doc_guidelines = False
+    guideline_popup = False
 
     if 'reportcriticalerror' in campaign_opts:
         critical_error = True
@@ -1468,7 +1470,27 @@ def pairwise_assessment(request, code=None, campaign_name=None):
         extra_guidelines = True
 
     if extra_guidelines:
-        priming_question_text += ' (see detailed guidelines below)'
+        # note this is not needed if DocLvlGuideline is enabled
+        priming_question_text += '<br/> (Please see the detailed guidelines below)'
+
+    if 'doclvlguideline' in campaign_opts:
+        use_sqm = True
+        doc_guidelines = True
+        guidelines_popup = (
+            'guidelinepopup' in campaign_opts or 'guidelinespopup' in campaign_opts
+        )
+
+    if doc_guidelines:
+        priming_question_text = (
+            'Above you see a paragraph in {0} and below its corresponding one or two candidate translations in {1}. '
+            'Please score the candidate translation(s) below following the detailed guidelines at the bottom of the page '
+            '<u><b>paying special attention to document-level properties, '
+            'such as consistency of style, selection of translation terms, formality, '
+            'and so on</b></u>, in addition to the usual correctness criteria. '.format(
+                source_language,
+                target_language,
+            )
+        )
 
     context = {
         'active_page': 'pairwise-assessment',
@@ -1495,6 +1517,8 @@ def pairwise_assessment(request, code=None, campaign_name=None):
         'sqm': use_sqm,
         'critical_error': critical_error,
         'source_error': source_error,
+        'guidelines_popup': guidelines_popup,
+        'doc_guidelines': doc_guidelines,
     }
     context.update(BASE_CONTEXT)
 
@@ -2128,9 +2152,7 @@ def pairwise_assessment_document(request, code=None, campaign_name=None):
             'Please score each paragraph of both candidate translations '
             '<u><b>paying special attention to document-level properties, '
             'such as consistency of formality and style, selection of translation terms, pronoun choice, '
-            'and so on</b></u>, in addition to the usual correctness criteria. '
-            'Note that sentences in each paragraph were separated by the <code>&lt;eos&gt;</code> tags '
-            'for convenience and this should not impact your assessment. '.format(
+            'and so on</b></u>, in addition to the usual correctness criteria. '.format(
                 len(block_items) - 1,
                 source_language,
                 target_language,


### PR DESCRIPTION
Changes proposed in the pull request:
- Fix a bug with unbound variables for staff users
- Add paragraph guidelines to segment-level contrastive tasks

@AppraiseDev/core-team
