### PR TITLE
[campaign] update: admin to introduce an action to download the results

### DIFF
--- a/Campaign/admin.py
+++ b/Campaign/admin.py
@@ -4,6 +4,15 @@ Campaign admin.py
 # pylint: disable=C0330,import-error
 from django.contrib import admin
 from django.contrib.admin.filters import AllValuesFieldListFilter
+from django.contrib.admin import AdminSite
+from django.urls import reverse
+from django.utils.html import format_html
+
+from django.http import HttpResponse
+import csv
+import zipfile
+from io import StringIO
+import importlib
 
 from Campaign.models import Campaign
 from Campaign.models import CampaignData
@@ -17,7 +26,7 @@ class DropdownFilter(AllValuesFieldListFilter):
     Experimental dropdown filter.
     """
 
-    template = 'Campaign/filter_select.html'
+    template = "Campaign/filter_select.html"
 
 
 class CampaignTeamAdmin(BaseMetadataAdmin):
@@ -26,33 +35,33 @@ class CampaignTeamAdmin(BaseMetadataAdmin):
     """
 
     list_display = [
-        'teamName',
-        'owner',
-        'teamMembers',
-        'requiredAnnotations',
-        'requiredHours',
-        'completionStatus',
+        "teamName",
+        "owner",
+        "teamMembers",
+        "requiredAnnotations",
+        "requiredHours",
+        "completionStatus",
     ] + BaseMetadataAdmin.list_display
-    list_filter = ['owner'] + BaseMetadataAdmin.list_filter
+    list_filter = ["owner"] + BaseMetadataAdmin.list_filter
     search_fields = [
-        'teamName',
-        'owner__username',
-        'owner__first_name',
-        'owner__last_name',
+        "teamName",
+        "owner__username",
+        "owner__first_name",
+        "owner__last_name",
     ] + BaseMetadataAdmin.search_fields
 
-    filter_horizontal = ['members']
+    filter_horizontal = ["members"]
 
     fieldsets = (
         (
             None,
             {
-                'fields': (
-                    'teamName',
-                    'owner',
-                    'members',
-                    'requiredAnnotations',
-                    'requiredHours',
+                "fields": (
+                    "teamName",
+                    "owner",
+                    "members",
+                    "requiredAnnotations",
+                    "requiredHours",
                 )
             },
         ),
@@ -65,22 +74,22 @@ class CampaignDataAdmin(BaseMetadataAdmin):
     """
 
     list_display = [
-        'dataName',
-        'market',
-        'metadata',
-        'dataValid',
-        'dataReady',
+        "dataName",
+        "market",
+        "metadata",
+        "dataValid",
+        "dataReady",
     ] + BaseMetadataAdmin.list_display
     list_filter = [
-        'dataValid',
-        'dataReady',
+        "dataValid",
+        "dataReady",
     ] + BaseMetadataAdmin.list_filter
     search_fields = [
         # nothing model specific
     ] + BaseMetadataAdmin.search_fields  # type: ignore
 
     fieldsets = (
-        (None, {'fields': ('dataFile', 'market', 'metadata')}),
+        (None, {"fields": ("dataFile", "market", "metadata")}),
     ) + BaseMetadataAdmin.fieldsets  # type: ignore
 
 
@@ -89,7 +98,7 @@ class CampaignAdmin(BaseMetadataAdmin):
     Model admin for Campaign instances.
     """
 
-    list_display = ['campaignName'] + BaseMetadataAdmin.list_display
+    list_display = ["campaignName"] + BaseMetadataAdmin.list_display
     list_filter = [
         # nothing model specific
     ] + BaseMetadataAdmin.list_filter  # type: ignore
@@ -97,22 +106,72 @@ class CampaignAdmin(BaseMetadataAdmin):
         # nothing model specific
     ] + BaseMetadataAdmin.search_fields  # type: ignore
 
-    filter_horizontal = ['batches']
+    filter_horizontal = ["batches"]
 
     fieldsets = (
         (
             None,
             {
-                'fields': (
-                    'campaignName',
-                    'packageFile',
-                    'teams',
-                    'batches',
-                    'campaignOptions',
+                "fields": (
+                    "campaignName",
+                    "packageFile",
+                    "teams",
+                    "batches",
+                    "campaignOptions",
                 )
             },
         ),
     ) + BaseMetadataAdmin.fieldsets  # type: ignore
+
+    actions = ["export_results"]
+
+    def _retrieve_csv(self, current_campaign):
+        # Get the task type  corresponding to the campaign
+        qs_name = current_campaign.get_campaign_type().lower()
+        qs_attr = "evaldata_{0}_campaign".format(qs_name)
+        qs_obj = getattr(current_campaign, qs_attr, None)
+        cls = type(qs_obj.all()[0])
+        cls_name = cls.__name__
+        cls_name = cls_name.replace("Task", "Result")
+        module = importlib.import_module(cls.__module__)
+        cls = getattr(module, cls_name)
+
+        # Now get the content
+        f = StringIO()
+        writer = csv.writer(f)
+        csv_content = cls.get_system_data(current_campaign.id, extended_csv=True)
+        for r in csv_content:
+            writer.writerow(r)
+
+        f.seek(0)
+        return f
+
+    def export_results(self, request, queryset):
+
+        if len(queryset) == 1:
+
+            current_campaign = queryset[0]
+            csv_content = self._retrieve_csv(current_campaign)
+            filename = f"results_{current_campaign.campaignName}.csv"
+            response = HttpResponse(csv_content, content_type="text/csv")
+            response["Content-Disposition"] = f"attachment; filename={filename}"
+        else:
+
+            response = HttpResponse(content_type='application/zip')
+            response['Content-Disposition'] = 'attachment; filename="campaign_results.zip"'
+
+            # Create a zip file with selected objects
+            with zipfile.ZipFile(response, 'w') as zipf:
+                for current_campaign in queryset:
+
+                    csv_content = self._retrieve_csv(current_campaign)
+                    # Add objects to the zip file, customize as per your model's data
+                    # For example, you can add an object's name and description to a text file in the zip
+                    filename = f"results_{current_campaign.campaignName}.csv"
+                    zipf.writestr(filename, csv_content.getvalue())
+        return response
+
+    export_results.short_description = "Download results"
 
 
 class TrustedUserAdmin(admin.ModelAdmin):
@@ -120,19 +179,19 @@ class TrustedUserAdmin(admin.ModelAdmin):
     Model admin for Campaign instances.
     """
 
-    list_display = ['user', 'campaign']
+    list_display = ["user", "campaign"]
     list_filter = [
-        ('campaign__campaignName', DropdownFilter),
+        ("campaign__campaignName", DropdownFilter),
         #      'campaign'
     ]
     search_fields = [  # type: ignore
         # nothing model specific
     ]
 
-    fieldsets = ((None, {'fields': ('user', 'campaign')}),)
+    fieldsets = ((None, {"fields": ("user", "campaign")}),)
 
 
+admin.site.register(Campaign, CampaignAdmin)
 admin.site.register(CampaignTeam, CampaignTeamAdmin)
 admin.site.register(CampaignData, CampaignDataAdmin)
-admin.site.register(Campaign, CampaignAdmin)
 admin.site.register(TrustedUser, TrustedUserAdmin)

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -898,6 +898,7 @@ class DataAssessmentResult(BaseMetadata):
                 'item_id',  # Real item ID
             )
 
+        system_data.append(attributes_to_extract)
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -765,6 +765,7 @@ class DirectAssessmentResult(BaseMetadata):
                 'item_id',  # Real item ID
             )
 
+        system_data.append(attributes_to_extract)
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -843,6 +843,7 @@ class DirectAssessmentContextResult(BaseMetadata):
                 'item_id',  # Real item ID
             )
 
+        system_data.append(attributes_to_extract)
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -901,6 +901,7 @@ class DirectAssessmentDocumentResult(BaseMetadata):
                 'item_id',  # Real item ID
             )
 
+        system_data.append(attributes_to_extract)
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -834,6 +834,7 @@ class PairwiseAssessmentResult(BaseMetadata):
                 'item_id',  # Real item ID
             )
 
+        system_data.append(attributes_to_extract)
         for _result in qs.values_list(*attributes_to_extract):
             results = [
                 (

--- a/EvalData/models/pairwise_assessment_document.py
+++ b/EvalData/models/pairwise_assessment_document.py
@@ -987,6 +987,7 @@ class PairwiseAssessmentDocumentResult(BaseMetadata):
                 'item_id',  # Real item ID
             )
 
+        system_data.append(attributes_to_extract)
         for _result in qs.values_list(*attributes_to_extract):
             results = [
                 (


### PR DESCRIPTION
Should solves this #51.

For now this is a draft as I am a bit confused of why there are so many methods to download CSV files in the task/result definitions. I think some cleaning should potentially be done there.