### PR TITLE
Migrate to Django 5

### DIFF
--- a/Campaign/models.py
+++ b/Campaign/models.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Dashboard.models import validate_language_code
 from EvalData.models import AnnotationTaskRegistry

--- a/EvalData/admin.py
+++ b/EvalData/admin.py
@@ -4,13 +4,14 @@ Appraise evaluation framework
 See LICENSE for usage details
 """
 # pylint: disable=C0330
+from datetime import timezone
+utc = timezone.utc
 from datetime import datetime
 
 from django.contrib import admin
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.utils.timezone import utc
 
 from .models import *
 

--- a/EvalData/models/base_models.py
+++ b/EvalData/models/base_models.py
@@ -4,6 +4,8 @@ Appraise evaluation framework
 See LICENSE for usage details
 """
 # pylint: disable=C0103,C0330,no-member
+from datetime import timezone
+utc = timezone.utc
 from datetime import datetime
 from datetime import timedelta
 from difflib import SequenceMatcher
@@ -15,8 +17,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.html import escape
 from django.utils.text import format_lazy as f
-from django.utils.timezone import utc
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/multi_modal_assessment.py
+++ b/EvalData/models/multi_modal_assessment.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -11,13 +11,14 @@ from traceback import format_exc
 from zipfile import is_zipfile
 from zipfile import ZipFile
 
+from datetime import timezone
+utc = timezone.utc
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.timezone import utc
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/pairwise_assessment_document.py
+++ b/EvalData/models/pairwise_assessment_document.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from django.contrib.auth.models import User
 from django.db import models
 from django.utils.text import format_lazy as f
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from Appraise.utils import _get_logger
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES

--- a/EvalData/models/task_agenda.py
+++ b/EvalData/models/task_agenda.py
@@ -11,7 +11,7 @@ from re import compile as re_compile
 from django.contrib import messages
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from deprecated import add_deprecated_method
 from EvalData.models.base_models import ObjectID

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -3,13 +3,14 @@ Appraise evaluation framework
 
 See LICENSE for usage details
 """
+from datetime import timezone
+utc = timezone.utc
 from datetime import datetime
 
 from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.shortcuts import render
-from django.utils.timezone import utc
 
 from Appraise.settings import BASE_CONTEXT
 from Appraise.utils import _get_logger

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,29 +6,37 @@
 2. Install Python 3.5+.
 3. Install virtual environments for Python:
 
-        pip3 install --user virtualenv
+```
+pip3 install --user virtualenv
+```
 
 4. Create environment for the project, activate it, and install Python
    requirements:
 
-        virtualenv venv -p python3
-        source ./venv/bin/activate
-        pip3 install -r requirements.txt
+```
+virtualenv venv -p python3
+source ./venv/bin/activate
+pip3 install -r requirements.txt
+```
 
 5. Create database, the first super user, and collect static files:
 
-        python manage.py migrate
-        python manage.py createsuperuser
-        python manage.py collectstatic --no-post-process
+```
+python manage.py migrate
+python manage.py createsuperuser
+python manage.py collectstatic --no-post-process
+```
 
-    Follow instructions on your screen; do not leave the password empty.
+Follow instructions on your screen; do not leave the password empty.
 
 6. Run the app on a local server:
 
-        python manage.py runserver
+```
+python manage.py runserver
+```
 
-    Open the browser at http://127.0.0.1:8000/.
-    The admin panel is available at http://127.0.0.1:8000/admin
+Open the browser at http://127.0.0.1:8000/.
+The admin panel is available at http://127.0.0.1:8000/admin
 
 
 ## Creating a new campaign

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
-Django<4
+django>=5
 django-stubs
 lxml
 psycopg2-binary


### PR DESCRIPTION
The current project requires Django 3, which is deprecated. This PR adds the minimal changes to make it work with Django 5, the current versions.

@AppraiseDev/core-team
