### PR TITLE
Fix total annotation time on campaign status page for overlapping timestamps

### DIFF
--- a/Campaign/tests.py
+++ b/Campaign/tests.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 
 from Campaign.models import _validate_package_file
 from Campaign.models import Campaign
+from Campaign.utils import _compute_user_total_annotation_time
 
 
 class TestInitCampaign(TestCase):
@@ -156,3 +157,34 @@ class TestInitCampaign(TestCase):
 
             with self.assertRaisesMessage(ValidationError, expected_msg):
                 _validate_package_file(campaign.packageFile)
+
+
+class TestCampaignUtils(TestCase):
+    '''Tests for Campaign utility functions.'''
+
+    def test_computing_user_total_annotation_time(self):
+        '''Verifies that user total annotation time is computed correctly.'''
+
+        # Non-overlapping timestamps with gaps
+        timestamps = [(100, 110), (120, 130), (140, 150), (160, 170), (180, 190)]
+        self.assertEqual(_compute_user_total_annotation_time(timestamps), 50)
+
+        # Consecutive timestamps
+        timestamps = [(100, 110), (110, 120), (120, 130), (130, 140), (140, 150)]
+        self.assertEqual(_compute_user_total_annotation_time(timestamps), 50)
+
+        # Partially overlapping timestamps
+        timestamps = [(100, 110), (105, 115), (110, 120), (115, 125), (120, 130)]
+        self.assertEqual(_compute_user_total_annotation_time(timestamps), 30)
+
+        # Same start timestamps
+        timestamps = [(100, 110), (100, 120), (100, 130), (100, 140), (100, 150)]
+        self.assertEqual(_compute_user_total_annotation_time(timestamps), 50)
+
+        # Overlapping timestamps in reverse order
+        timestamps = [(120, 130), (115, 125), (110, 120), (105, 115), (100, 110)]
+        self.assertEqual(_compute_user_total_annotation_time(timestamps), 30)
+
+        # Same start and end timestamps
+        timestamps = [(100, 100), (100, 100), (100, 100), (100, 100), (150, 150)]
+        self.assertEqual(_compute_user_total_annotation_time(timestamps), 0)

--- a/Campaign/utils.py
+++ b/Campaign/utils.py
@@ -23,6 +23,36 @@ from EvalData.models import ObjectID
 from EvalData.models import TaskAgenda
 
 
+def _compute_user_total_annotation_time(timestamps):
+    """
+    Computes total annotation time for a single user based on pairs of start and
+    end timestamps excluding overlapping portions of annotations.
+
+    :param timestamps: list of (start_timestamp, end_timestamp) pairs
+    :return: total annotation time in seconds
+    """
+    # Sort timestamps by start timestamp
+    timestamps = sorted(timestamps, key=lambda x: x[0])
+
+    total_annotation_time = 0
+    previous_end_timestamp = None
+    for start_timestamp, end_timestamp in timestamps:
+        # If there is no previous end timestamp or the current start timestamp is after the previous end timestamp
+        if previous_end_timestamp is None or start_timestamp >= previous_end_timestamp:
+            # Add the duration of the current annotation to the total annotation time
+            total_annotation_time += end_timestamp - start_timestamp
+
+        # If the current start timestamp is before the previous end timestamp
+        else:
+            # Add the duration of the non-overlapping portion of the current annotation to the total annotation time
+            total_annotation_time += end_timestamp - previous_end_timestamp
+
+        # Update the previous end timestamp
+        previous_end_timestamp = end_timestamp
+
+    return total_annotation_time
+
+
 def _create_uniform_task_map(annotators, tasks, redudancy):
     """
     Creates task maps, uniformly distributed across given annotators.


### PR DESCRIPTION
This PR should fix issues with too large total annotation times displayed on the campaign status page for PairwiseDocument tasks and potentially also for ESA tasks. In PairwiseDocument tasks, start timestamp is the same for all paragraphs within a document, so a solution was to exclude overlapping portions of paragraph-level annotation times when computing the total.

@hitokazm, please feel free to merge and re-sync the instance.

@zouharvi, FYI. We will be able to confirm if this fix also solves similar issues in ESA campaigns once we pull these changes to the instance and compare campaign status pages in existing campaigns.

