### PR TITLE
Clamp times, fix status annotation counts

### DIFF
--- a/Appraise/utils.py
+++ b/Appraise/utils.py
@@ -17,3 +17,41 @@ def _get_logger(name):
     named_logger.setLevel(LOG_LEVEL)
     named_logger.addHandler(LOG_HANDLER)
     return named_logger
+
+
+def _compute_user_total_annotation_time(timestamps):
+    """
+    Computes total annotation time for a single user based on pairs of start and
+    end timestamps excluding overlapping portions of annotations.
+
+    :param timestamps: list of (start_timestamp, end_timestamp) pairs
+    :return: total annotation time in seconds
+    """
+    # Sort timestamps by start timestamp
+    timestamps = sorted(timestamps, key=lambda x: x[0])
+
+    def _clamp_time(seconds):
+        # if a segment takes longer than 10 minutes, set it to 5 minutes
+        # it's likely due to inactivity
+        if seconds >= 10*60:
+            return 5*60
+        else:
+            return seconds
+
+    total_annotation_time = 0
+    previous_end_timestamp = None
+    for start_timestamp, end_timestamp in timestamps:
+        # If there is no previous end timestamp or the current start timestamp is after the previous end timestamp
+        if previous_end_timestamp is None or start_timestamp >= previous_end_timestamp:
+            # Add the duration of the current annotation to the total annotation time
+            total_annotation_time += _clamp_time(end_timestamp - start_timestamp)
+
+        # If the current start timestamp is before the previous end timestamp
+        else:
+            # Add the duration of the non-overlapping portion of the current annotation to the total annotation time
+            total_annotation_time += _clamp_time(end_timestamp - previous_end_timestamp)
+
+        # Update the previous end timestamp
+        previous_end_timestamp = end_timestamp
+
+    return total_annotation_time

--- a/Campaign/utils.py
+++ b/Campaign/utils.py
@@ -34,18 +34,26 @@ def _compute_user_total_annotation_time(timestamps):
     # Sort timestamps by start timestamp
     timestamps = sorted(timestamps, key=lambda x: x[0])
 
+    def _clamp_time(seconds):
+        # if a segment takes longer than 10 minutes, set it to 5 minutes
+        # it's likely due to inactivity
+        if seconds >= 10*60:
+            return 5*60
+        else:
+            return seconds
+
     total_annotation_time = 0
     previous_end_timestamp = None
     for start_timestamp, end_timestamp in timestamps:
         # If there is no previous end timestamp or the current start timestamp is after the previous end timestamp
         if previous_end_timestamp is None or start_timestamp >= previous_end_timestamp:
             # Add the duration of the current annotation to the total annotation time
-            total_annotation_time += end_timestamp - start_timestamp
+            total_annotation_time += _clamp_time(end_timestamp - start_timestamp)
 
         # If the current start timestamp is before the previous end timestamp
         else:
             # Add the duration of the non-overlapping portion of the current annotation to the total annotation time
-            total_annotation_time += end_timestamp - previous_end_timestamp
+            total_annotation_time += _clamp_time(end_timestamp - previous_end_timestamp)
 
         # Update the previous end timestamp
         previous_end_timestamp = end_timestamp

--- a/Campaign/utils.py
+++ b/Campaign/utils.py
@@ -23,44 +23,6 @@ from EvalData.models import ObjectID
 from EvalData.models import TaskAgenda
 
 
-def _compute_user_total_annotation_time(timestamps):
-    """
-    Computes total annotation time for a single user based on pairs of start and
-    end timestamps excluding overlapping portions of annotations.
-
-    :param timestamps: list of (start_timestamp, end_timestamp) pairs
-    :return: total annotation time in seconds
-    """
-    # Sort timestamps by start timestamp
-    timestamps = sorted(timestamps, key=lambda x: x[0])
-
-    def _clamp_time(seconds):
-        # if a segment takes longer than 10 minutes, set it to 5 minutes
-        # it's likely due to inactivity
-        if seconds >= 10*60:
-            return 5*60
-        else:
-            return seconds
-
-    total_annotation_time = 0
-    previous_end_timestamp = None
-    for start_timestamp, end_timestamp in timestamps:
-        # If there is no previous end timestamp or the current start timestamp is after the previous end timestamp
-        if previous_end_timestamp is None or start_timestamp >= previous_end_timestamp:
-            # Add the duration of the current annotation to the total annotation time
-            total_annotation_time += _clamp_time(end_timestamp - start_timestamp)
-
-        # If the current start timestamp is before the previous end timestamp
-        else:
-            # Add the duration of the non-overlapping portion of the current annotation to the total annotation time
-            total_annotation_time += _clamp_time(end_timestamp - previous_end_timestamp)
-
-        # Update the previous end timestamp
-        previous_end_timestamp = end_timestamp
-
-    return total_annotation_time
-
-
 def _create_uniform_task_map(annotators, tasks, redudancy):
     """
     Creates task maps, uniformly distributed across given annotators.

--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -15,9 +15,8 @@ from django.contrib.auth.decorators import login_required
 from django.core.management.base import CommandError
 from django.http import HttpResponse
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Campaign.utils import _get_campaign_instance
-from Campaign.utils import _compute_user_total_annotation_time
 from EvalData.models import DataAssessmentResult
 from EvalData.models import DirectAssessmentDocumentResult
 from EvalData.models import PairwiseAssessmentDocumentResult

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import AnnotationTaskRegistry
 from EvalData.models.base_models import BaseMetadata
@@ -576,12 +576,11 @@ class DataAssessmentResult(BaseMetadata):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
 
     @classmethod
     def get_system_annotations(cls):

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import AnnotationTaskRegistry
 from EvalData.models.base_models import BaseMetadata
@@ -438,12 +438,11 @@ class DirectAssessmentResult(BaseMetadata):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
 
     @classmethod
     def get_system_annotations(cls):

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import AnnotationTaskRegistry
 from EvalData.models.base_models import BaseMetadata
@@ -504,12 +504,12 @@ class DirectAssessmentContextResult(BaseMetadata):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
+    
 
     @classmethod
     def get_system_annotations(cls):

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -17,7 +17,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import AnnotationTaskRegistry
 from EvalData.models.base_models import BaseAssessmentResult
@@ -634,12 +634,11 @@ class DirectAssessmentDocumentResult(BaseAssessmentResult):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
 
     @classmethod
     def get_system_annotations(cls):

--- a/EvalData/models/multi_modal_assessment.py
+++ b/EvalData/models/multi_modal_assessment.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import AnnotationTaskRegistry
 from EvalData.models.base_models import BaseMetadata
@@ -488,12 +488,11 @@ class MultiModalAssessmentResult(BaseMetadata):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
 
     @classmethod
     def compute_accurate_group_status(cls):

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -21,7 +21,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import *
 
@@ -494,12 +494,11 @@ class PairwiseAssessmentResult(BasePairwiseAssessmentResult):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
 
     @classmethod
     def get_system_annotations(cls):

--- a/EvalData/models/pairwise_assessment_document.py
+++ b/EvalData/models/pairwise_assessment_document.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.text import format_lazy as f
 from django.utils.translation import gettext_lazy as _
 
-from Appraise.utils import _get_logger
+from Appraise.utils import _get_logger, _compute_user_total_annotation_time
 from Dashboard.models import LANGUAGE_CODES_AND_NAMES
 from EvalData.models.base_models import AnnotationTaskRegistry
 from EvalData.models.base_models import BaseMetadata
@@ -621,12 +621,11 @@ class PairwiseAssessmentDocumentResult(BaseMetadata):
     def get_time_for_user(cls, user):
         results = cls.objects.filter(createdBy=user, activated=False, completed=True)
 
-        durations = []
+        timestamps = []
         for result in results:
-            duration = result.end_time - result.start_time
-            durations.append(duration)
+            timestamps.append((result.start_time, result.end_time))
 
-        return seconds_to_timedelta(sum(durations))
+        return seconds_to_timedelta(_compute_user_total_annotation_time(timestamps))
 
     @classmethod
     def get_system_annotations(cls):

--- a/Examples/DirectMQM/README.md
+++ b/Examples/DirectMQM/README.md
@@ -22,7 +22,7 @@ python3 manage.py StartNewCampaign Examples/DirectMQM/manifest_mqm.json \
    
 python3 manage.py StartNewCampaign Examples/DirectMQM/manifest_esa_gemba.json \
     --batches-json Examples/DirectMQM/batches_wmt23_en-de_esa_gemba.json \
-    --csv-output Examples/DirectMQM/output_esa.csv;
+    --csv-output Examples/DirectMQM/output_esa_gemba.csv;
 
 python3 manage.py runserver;
 


### PR DESCRIPTION
**Fixes**:
- Clamp times: if the segment time is higher than 10 minutes, it gets turned into 5 minutes. This applies just for the campaign status page and does not modify the annotation data.
- Computation of finished annotations which didn't sum up to 100 before.

**Additionally**:
The times are clamped only on the campaign status page and the annotator end screen still showed the raw data.
![image](https://github.com/AppraiseDev/Appraise/assets/7661193/b74d1fec-ca51-4aaf-a37e-7e3cfbb4be57)

To fix this, I had to change a few files and move the time computation function to Appraise/utils (otherwise we get circular import EvalData->Campaign->EvalData). Now the time compuation logic is unified:

![image](https://github.com/AppraiseDev/Appraise/assets/7661193/c6be32f4-b04b-4aef-9fc0-37d7a0fcc41c)

Should be rebased to romang/develop-mqm.