### PR TITLE
Enable HTML in ESA/MQM sourceText

### DIFF
--- a/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
+++ b/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
@@ -49,6 +49,10 @@
     line-height: 120%;
 }
 
+.source-text > audio, .source-text > video {
+    width: 100%;
+}
+
 .tutorial-text {
     text-align: center;
     color: #257;

--- a/EvalView/templates/EvalView/direct-assessment-document-mqm-esa.html
+++ b/EvalView/templates/EvalView/direct-assessment-document-mqm-esa.html
@@ -77,7 +77,7 @@
         <div class="source-box">
             <div class="tutorial-text"></div>
             <div class="source-text">
-                {{ item.sourceText }}
+                {{ item.sourceText|safe }}
             </div>
 
             <div class="target-text">

--- a/Examples/DirectMQM/README.md
+++ b/Examples/DirectMQM/README.md
@@ -1,7 +1,8 @@
-# Appraise Evaluation System
+# Direct MQM/ESA
 
-Generating an example campaign with direct assessment tasks with SQM quality
-levels. Note it uses exact same batches as standard direct assessment tasks:
+## Setup
+
+This is an example of 3 campaigns with MQM/ESA/ESAAI (three different batches).
 
 ```
 # clean up previous iteration
@@ -30,4 +31,27 @@ python3 manage.py runserver;
 # Collect some annotations, then export annotation scores...
 
 python3 manage.py ExportSystemScoresToCSV example16mqm
+```
+
+## Audio/Video
+
+The source field accepts HTML, so it's very easy to add multimodal support by including HTML snippets in the `sourceText` field like so:
+
+HTML for video:
+```
+<video
+    src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4"
+    controls
+    disablepictureinpicture
+    preload="auto"
+    controlslist="nodownload"
+></video>
+```
+
+HTML for audio:
+```
+<audio
+    src='https://samplelib.com/lib/preview/mp3/sample-3s.mp3'
+    controls controlslist='nodownload'
+></audio>
 ```


### PR DESCRIPTION
With minor changes to ESA/MQM view we get multimodal support (resolves #160).

HTML for video (`sourceText`):
```
<video
    src="https://samplelib.com/lib/preview/mp4/sample-5s.mp4"
    controls
    disablepictureinpicture
    preload="auto"
    controlslist="nodownload"
></video>
```

HTML for audio (`sourceText`):
```
<audio
    src='https://samplelib.com/lib/preview/mp3/sample-3s.mp3'
    controls controlslist='nodownload'
></audio>
```

[example_small.webm](https://github.com/user-attachments/assets/5df9b2e5-4142-43c5-9c47-7ccd15b02acd)

