### PR TITLE
Refactor/Fix ESA template and item loading

### DIFF
--- a/EvalView/templates/EvalView/direct-assessment-document-mqm-esa.html
+++ b/EvalView/templates/EvalView/direct-assessment-document-mqm-esa.html
@@ -21,9 +21,9 @@
         <tr>
             <td style="width:33%;text-align:left;">
                 <strong id="task_progress">
-                    document {{completed_blocks}} / {{total_blocks}}
+                    document {{docs_completed}} / {{docs_total}}
                     &nbsp;&nbsp;&nbsp;
-                    segment {{item_id}}/100
+                    segment {{items_completed}}/100
                 </strong>
             </td>
             <td style="width:33%;text-align:center;"></td>

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -1133,12 +1133,11 @@ def direct_assessment_document_mqmesa(campaign, current_task, request):
     # task belongs to, and collect some additional statistics
     (
         next_item,
-        completed_items,
-        completed_docs,
-        completed_items_in_doc,
+        items_completed,
+        docs_completed,
         doc_items,
         doc_items_results,
-        total_blocks,
+        docs_total,
     ) = current_task.next_document_for_user_mqmesa(request.user)
 
     if not next_item:
@@ -1167,7 +1166,7 @@ def direct_assessment_document_mqmesa(campaign, current_task, request):
         for item, result in zip(doc_items, doc_items_results)
     ]
 
-    LOGGER.info(f'completed_items={completed_items}, completed_docs={completed_docs}')
+    LOGGER.info(f'items_completed={items_completed}, docs_completed={docs_completed}')
 
     source_language = current_task.marketSourceLanguage()
     target_language = current_task.marketTargetLanguage()
@@ -1178,17 +1177,12 @@ def direct_assessment_document_mqmesa(campaign, current_task, request):
         'item_id': next_item.itemID,
         'task_id': next_item.id,
         'document_id': next_item.documentID,
-        'completed_blocks': completed_docs,
-        'total_blocks': total_blocks,
-        'items_left_in_block': len(doc_items) - completed_items_in_doc,
+        'items_completed': items_completed,
+        'docs_completed': docs_completed,
+        'docs_total': docs_total,
         'source_language': source_language,
         'target_language': target_language,
-        'source_item_type': "text",
-        'target_item_type': "text",
-        'template_debug': 'debug' in request.GET,
         'campaign': campaign.campaignName,
-        'datask_id': current_task.id,
-        'trusted_user': current_task.is_trusted_user(request.user),
         # Task variations
         'ui_lang': "enu",
         'mqm_type': 'ESA' if 'esa' in campaign_opts else "MQM",


### PR DESCRIPTION
- Remove unnecessary data being passed to the ESA template.
- Generating batches with the way they are meant to be generated (#162) breaks the next item loading and displays. This PR fixes that.


@snukky I think we're needlessly losing a lot of compute on this. Do you know how to make JOIN here? The list is exactly 100 items but still would be faster than this lookup that happens on each page load. I tried a few things but I'm quite unfamiliar with Django.
```
        # Retrieve all items from the document which next_item belongs to
        all_items = self.items.all()
        
        # TODO: this is super compute heavy and inefficient
        # should actually be table JOIN
        def get_item_result(id):
            return DirectAssessmentDocumentResult.objects.filter(
                item__itemID=id,
                createdBy=user,
                task=self,
            ).last()

        all_items = [(item, get_item_result(item.itemID)) for item in all_items]
```