### PR TITLE
Annotator Quality of Life

### DIFF
--- a/Dashboard/templates/Dashboard/base.html
+++ b/Dashboard/templates/Dashboard/base.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>{{ title }}</title>
-
+    <link rel="icon" href="data:,">
     <!-- Bootstrap v3.4.1 (legacy) -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css">
     <!-- jQuery v3.7.1 -->

--- a/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
+++ b/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
@@ -70,6 +70,14 @@
     background-color: #ccc;
 }
 
+#button-next-doc-fake {
+    background: #a77;
+    border-color: #944;
+    color: #ecc;
+    font-size: 18pt;
+    cursor: not-allowed;
+}
+
 #button-next-doc {
     background: #7a7;
     border-color: #494;

--- a/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
+++ b/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
@@ -14,6 +14,22 @@
     font-size: 80%;
 }
 
+.slider-bubble {
+    z-index: 100;
+    position: relative;
+    top: -35px;
+    left: -10px;
+
+    width: 40px;
+    height: 30px;
+    background-color: #79c;
+    border-radius: 6px;
+    text-align: center;
+    font-size: 19px;
+
+    color: black;
+}
+
 .quotelike {
     border-left: 5px solid #ddd;
 }

--- a/EvalView/static/EvalView/js/direct-assessment-document-mqm-esa.js
+++ b/EvalView/static/EvalView/js/direct-assessment-document-mqm-esa.js
@@ -144,7 +144,7 @@ $(document).ready(() => {
     });
 
     // hide next doc button for now
-    $("#button-next-doc").toggle(false)
+    toggle_doc_button(false)
     $("#button-next-doc").on("click", () => submit_finish_document(false))
 
     $(".item-box").each((_i, el) => {
@@ -258,6 +258,11 @@ function _show_error_box(text, timeout = 2000) {
 
 function fuzzy_abs_match(a, b, tol) {
     return a == b || Math.abs(a - b) <= tol
+}
+
+function toggle_doc_button(visible) {
+    $("#button-next-doc").toggle(visible)
+    $("#button-next-doc-fake").toggle(!visible)
 }
 
 class MQMItemHandler {
@@ -386,7 +391,8 @@ class MQMItemHandler {
         this.el.attr("data-item-completed", "False")
         this.initialize()
         // if we reset then we automatically hide the next doc button
-        $("#button-next-doc").toggle(false)
+        toggle_doc_button(false)
+        this.el_slider.slider('value', 0)
     }
 
     remove_undecided(mqm_object) {
@@ -421,7 +427,7 @@ class MQMItemHandler {
         this.check_status()
 
         if (mark_complete && _all_sentences_scored()) {
-            $("#button-next-doc").toggle(true)
+            toggle_doc_button(true)
         }
 
         return true

--- a/EvalView/static/EvalView/js/direct-assessment-document-mqm-esa.js
+++ b/EvalView/static/EvalView/js/direct-assessment-document-mqm-esa.js
@@ -175,7 +175,6 @@ $(document).ready(() => {
 
 function _all_sentences_scored() {
     let items_left = $('.item-box').filter((_i, el) => $(el).attr('data-item-completed') == "False").length;
-    console.log('Items left:', items_left);
     return items_left == 0;
 }
 
@@ -334,6 +333,29 @@ class MQMItemHandler {
             this.el_slider.slider('value', score);
         }
 
+        // slider bubble handling
+        this.el_slider.find(".ui-slider-handle").append("<div class='slider-bubble'>100</div>")
+        let refresh_bubble = () => {
+            this.el_slider.find(".slider-bubble").text(this.el_slider.slider('value'))
+        }
+        this.el_slider.find(".ui-slider-handle").on("mousedown ontouchstart", () => {
+            this.el_slider.find(".slider-bubble").toggle(true);
+            refresh_bubble();
+        })
+        this.el_slider.find(".ui-slider-handle").on("mouseup focusout ontouchend", async () => {
+            await waitout_js_loop()
+            this.el_slider.find(".slider-bubble").toggle(false);
+            refresh_bubble();
+        })
+        this.el_slider.on("slide", async () => {
+            this.el_slider.find(".slider-bubble").toggle(true);
+            refresh_bubble()
+            await waitout_js_loop()
+            refresh_bubble()
+        });
+        // hide by default
+        this.el_slider.find(".slider-bubble").toggle(false);
+
         this.el.find('.button-submit').on("click", (event) => { event.preventDefault(); this.note_change() });
     }
 
@@ -389,6 +411,7 @@ class MQMItemHandler {
     reset() {
         this.el.find('.button-submit').toggle(MQM_TYPE == "MQM")
         this.el.attr("data-item-completed", "False")
+        this.el_slider.find(".slider-bubble").remove()
         this.initialize()
         // if we reset then we automatically hide the next doc button
         toggle_doc_button(false)

--- a/EvalView/templates/EvalView/direct-assessment-document-mqm-esa.html
+++ b/EvalView/templates/EvalView/direct-assessment-document-mqm-esa.html
@@ -123,8 +123,21 @@
     <input name="ajax" type="hidden" value="False" />
 </form>
 
-<button class="btn btn-primary" style="margin-left: auto; margin-right: auto; display: block;" id="button-next-doc">
+<button
+    class="btn btn-primary"
+    style="margin-left: auto; margin-right: auto; display: block;"
+    id="button-next-doc"
+>
     Continue to next document
+</button>
+
+<button
+    class="btn btn-primary"
+    style="margin-left: auto; margin-right: auto; display: block;"
+    id="button-next-doc-fake"
+    title="Please first complete all items in the document (error spans + scores)."
+>
+    Continue to next document (unavailable)
 </button>
 
 {% endblock %}


### PR DESCRIPTION
This PR makes three changes.

- Adds a new "next document button" state with a tooltip. Thus the button is always visible (#146). The tooltip is unfortunately not visible in the video (Xorg...)
- Fixes a bug where the slider would not be reset.

[Screencast from 2024-07-19 12-39-26.webm](https://github.com/user-attachments/assets/4e74c361-e9cd-42ab-9f4b-beb8b8f5e8b3)


- Adds a slider bubble for more precise scoring. This makes it easier for annotators that e.g. remember that they assigned the score of 70 to a similar error previously.

[Screencast from 2024-07-19 13-01-51.webm](https://github.com/user-attachments/assets/3c12279b-7623-4ffb-b4e9-a91f17e49525)

- A bit unrelated but makes the browser stop requesting a favicon (and hence spamming the console with errors).

![Screenshot from 2024-07-19 13-02-20](https://github.com/user-attachments/assets/63cbb263-17f3-4f0f-b978-12159ae8d250)
