### PR TITLE
pre-WMT24 test changes

### DIFF
--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -102,14 +102,14 @@ def campaign_status(request, campaign_name, sort_key=2):
                     'item__itemID',
                     'item__targetID',
                     'item__itemType',
-                    'item__sourceText',
+                    'item__id',
                     'item__documentID',
                 )
                 # compute time override based on document times
                 import collections
                 _time_pairs = collections.defaultdict(list)
                 for x in _data:
-                    _time_pairs[x[7]].append((x[0], x[1]))
+                    _time_pairs[x[7]+ " ||| " +x[4]].append((x[0], x[1]))
                 _time_pairs = [
                     (min([x[0] for x in doc_v]), max([x[1] for x in doc_v]))
                     for doc, doc_v in _time_pairs.items()
@@ -127,14 +127,14 @@ def campaign_status(request, campaign_name, sort_key=2):
                     'item__itemID',
                     'item__targetID',
                     'item__itemType',
-                    'item__sourceText',
+                    'item__id',
                     'item__documentID',
                 )
                 # compute time override based on document times
                 import collections
                 _time_pairs = collections.defaultdict(list)
                 for x in _data:
-                    _time_pairs[x[7]].append((x[0], x[1]))
+                    _time_pairs[x[7]+ " ||| " +x[4]].append((x[0], x[1]))
                 _time_pairs = [
                     (min([x[0] for x in doc_v]), max([x[1] for x in doc_v]))
                     for doc, doc_v in _time_pairs.items()
@@ -194,7 +194,7 @@ def campaign_status(request, campaign_name, sort_key=2):
             if _annotation_time:
                 _hours = int(floor(_annotation_time / 3600))
                 _minutes = int(floor((_annotation_time % 3600) / 60))
-                _annotation_time = '{0:0>2d}h{1:0>2d}m'.format(_hours, _minutes)
+                _annotation_time = f'{_hours:0>2d}h{_minutes:0>2d}m'
             else:
                 _annotation_time = 'n/a'
 
@@ -263,12 +263,10 @@ def stat_reliable_testing(_data, campaign_opts, result_type):
         # Script generating batches for data assessment task does not
         # keep equal itemIDs for respective TGT and BAD items, so it
         # cannot be used as a key.
-        if "esa" in campaign_opts or "mqm" in campaign_opts:
-            _key = str(_x[6]) + " ||| " + _x[4]
-        elif result_type is DataAssessmentResult:
-            _key = str(_x[4])
+        if result_type is DataAssessmentResult:
+            _key = f"{_x[4]}"
         else:
-            _key = '{0}-{1}'.format(_x[3], _x[4])
+            _key = f'{_x[3]}-{_x[4]}'
         _dst[_key].append(_z_score)
 
     _x = []
@@ -284,10 +282,6 @@ def stat_reliable_testing(_data, campaign_opts, result_type):
 
             _t, pvalue = mannwhitneyu(_x, _y, alternative='less')
             _reliable = pvalue
-
-        except ImportError:
-            print("scipy is not installed")
-            pass
 
         # Possible for mannwhitneyu() to throw in some scenarios
         except ValueError:

--- a/Dashboard/templates/Dashboard/dashboard.html
+++ b/Dashboard/templates/Dashboard/dashboard.html
@@ -10,7 +10,7 @@
           -->
 
         <h1>Dashboard</h1>
-        <h4>Evaluation campaign for shared tasks hosted at <a href="https://statmt.org/wmt23">the 8th Conference on Machine Translation</a> (WMT23)</h4>
+        <h4>Evaluation campaign for shared tasks hosted at <a href="https://statmt.org/wmt24">the 9th Conference on Machine Translation</a> (WMT24)</h4>
 
         <div class="panel panel-primary" style="margin-top: 20px;">
           <div class="panel-heading">

--- a/Dashboard/utils.py
+++ b/Dashboard/utils.py
@@ -84,7 +84,6 @@ def run_quality_control(username):
             'item__target1ID',
             'item__itemType',
             'item__id',
-            'item__sourceText',
         )
     else:
         _data = _data.values_list(
@@ -95,7 +94,6 @@ def run_quality_control(username):
             'item__targetID',
             'item__itemType',
             'item__id',
-            'item__sourceText',
         )
 
     _annotations = len(set([x[6] for x in _data]))
@@ -124,10 +122,7 @@ def run_quality_control(username):
 
         _z_score = (_x[2] - _user_mean) / _user_stdev
 
-        if "esa" in campaign_opts:
-            _key = f"{_x[7]} ||| {_x[4]}"
-        else:
-            _key = f'{_x[3]}-{_x[4]}'
+        _key = f'{_x[3]}-{_x[4]}'
 
         _dst[_key].append(_z_score)
 

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -26,9 +26,6 @@ from EvalData.models.base_models import MAX_REQUIREDANNOTATIONS_VALUE
 from EvalData.models.base_models import seconds_to_timedelta
 from EvalData.models.direct_assessment_context import TextPairWithContext
 
-# TODO: Unclear if these are needed?
-# from Appraise.settings import STATIC_URL, BASE_CONTEXT
-
 LOGGER = _get_logger(name=__name__)
 
 
@@ -286,7 +283,6 @@ class DirectAssessmentDocumentTask(BaseMetadata):
         })
         
         if not unfinished_items:
-            # TODO: the None might not be the correct type
             return (
                 None,
                 items_completed,
@@ -298,10 +294,13 @@ class DirectAssessmentDocumentTask(BaseMetadata):
 
         # things are ordered with batch order
         next_item = unfinished_items[0]
-        doc_items = [i for i, r in all_items if i.documentID == next_item.documentID]
-        doc_items_results = [
-            r for i, r in all_items if i.documentID == next_item.documentID
+        doc_items_all = [
+            (i, r) for i, r in all_items
+            # match document name and system
+            if i.documentID == next_item.documentID and i.targetID == next_item.targetID
         ]
+        doc_items = [i for i, r in doc_items_all]
+        doc_items_results = [r for i, r in doc_items_all]
 
         print(
             f'Completed {docs_completed}/{docs_total} documents, '

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -613,7 +613,7 @@ class DirectAssessmentDocumentResult(BaseAssessmentResult):
             import collections
             timestamps = collections.defaultdict(list)
             for result in results:
-                timestamps[result.item.documentID].append((result.start_time, result.end_time))
+                timestamps[result.item.documentID+" ||| "+result.item.targetID].append((result.start_time, result.end_time))
 
             # timestamps are document-level now, but that does not change anything later on
             timestamps = [

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -264,50 +264,57 @@ class DirectAssessmentDocumentTask(BaseMetadata):
             doc_items_results,
             total_docs,
         """
-        # Retrieve all items from the document which next_item belongs to
-        all_items = self.items.all()
-        
-        # TODO: this is super compute heavy and inefficient
-        # should actually be table JOIN
-        def get_item_result(id):
-            return DirectAssessmentDocumentResult.objects.filter(
-                item__itemID=id,
-                createdBy=user,
-                task=self,
-            ).last()
 
-        all_items = [(item, get_item_result(item.itemID)) for item in all_items]
+        # get all items (100) and try to find resul
+        all_items = [
+            (
+                item, 
+                DirectAssessmentDocumentResult.objects.filter(
+                    item=item, activated=False, completed=True, createdBy=user
+                ).last()
+            )
+            for item in self.items.all().order_by('id')
+        ]
         unfinished_items = [i for i, r in all_items if not r]
+        
+        docs_total = len({i.documentID for i, r in all_items})
+        items_completed = len([
+            i for i, r in all_items if r and r.completed
+        ])
+        docs_completed = docs_total - len({
+            i.documentID for i, r in all_items if r is None or not r.completed
+        })
+        
         if not unfinished_items:
             # TODO: the None might not be the correct type
-            return (None, all_items, 0, 0, [], [], 0)
+            return (
+                None,
+                items_completed,
+                docs_completed,
+                [],
+                [],
+                docs_total,
+            )
+
         # things are ordered with batch order
         next_item = unfinished_items[0]
-
-        docs_all = len({i.documentID for i, r in all_items})
-        completed_items = len(
-            [i for i, r in all_items if r is not None and r.completed]
-        )
-        completed_docs = docs_all - len(
-            {i.documentID for i, r in all_items if r is None or not r.completed}
-        )
         doc_items = [i for i, r in all_items if i.documentID == next_item.documentID]
         doc_items_results = [
             r for i, r in all_items if i.documentID == next_item.documentID
         ]
 
         print(
-            f'Completed {completed_docs}/{docs_all} documents, '
-            f'completed {completed_items} items in total'
+            f'Completed {docs_completed}/{docs_total} documents, '
+            f'completed {items_completed} items in total'
         )
 
         return (
-            next_item,  # the first unannotated item for the user
-            completed_items,  # the number of completed items in the task
-            completed_docs,  # the number of completed documents in the task
-            doc_items,  # all items from the current document
-            doc_items_results,  # all score results from the current document
-            docs_all,  # the total number of documents in the task
+            next_item,         # the first unannotated item for the user
+            items_completed,   # the number of completed items in the task
+            docs_completed,    # the number of completed documents in the task
+            doc_items,         # all items from the current document
+            doc_items_results, # all score results from the current document
+            docs_total,        # the total number of documents in the task
         )
 
     def get_results_for_each_item(self, block_items, user):
@@ -364,31 +371,6 @@ class DirectAssessmentDocumentTask(BaseMetadata):
             if active_users < active_task.requiredAnnotations:
                 if user and not user in active_task.assignedTo.all():
                     return active_task
-
-        return None
-
-        # It seems that assignedTo is converted to an integer count.
-        active_tasks = active_tasks.order_by('id').values_list(
-            'id', 'requiredAnnotations', 'assignedTo'
-        )
-
-        for active_task in active_tasks:
-            print(active_task)
-            active_users = active_task[2] or 0
-            if active_users < active_task[1]:
-                return cls.objects.get(pk=active_task[0])
-
-        return None
-
-        # TODO: this needs to be removed.
-        for active_task in active_tasks:
-            market = active_task.items.first().metadata.market
-            if not market.targetLanguageCode == code:
-                continue
-
-            active_users = active_task.assignedTo.count()
-            if active_users < active_task.requiredAnnotations:
-                return active_task
 
         return None
 

--- a/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
+++ b/EvalView/static/EvalView/css/direct-assessment-document-mqm-esa.css
@@ -14,6 +14,10 @@
     font-size: 80%;
 }
 
+.ui-slider-horizontal {
+    background: #ddd !important;
+}
+
 .slider-bubble {
     z-index: 100;
     position: relative;

--- a/EvalView/static/EvalView/js/direct-assessment-document-mqm-esa.js
+++ b/EvalView/static/EvalView/js/direct-assessment-document-mqm-esa.js
@@ -347,6 +347,16 @@ class MQMItemHandler {
             this.el_slider.find(".slider-bubble").toggle(false);
             refresh_bubble();
         })
+
+        this.el_slider.find(".ui-slider-handle").on("mouseup ontouchend", async () => {
+            let value = this.el_slider.slider('value')
+            if (this.tutorial) {
+                // do nothing, we don't validate during tutorial
+            } else if (this.mqm.length == 0 && value < 66) {
+                alert(`You assigned a score of ${value} without highlighting any errors. Please, highlight errors first.`)
+            }
+        })
+
         this.el_slider.on("slide", async () => {
             this.el_slider.find(".slider-bubble").toggle(true);
             refresh_bubble()

--- a/EvalView/views.py
+++ b/EvalView/views.py
@@ -1091,8 +1091,10 @@ def direct_assessment_document_mqmesa(campaign, current_task, request):
 
 
         db_item = current_task.items.filter(
-            itemID=item_id
-        ).order_by('itemID')
+            itemID=item_id,
+            id=task_id,
+        )
+
 
         if len(db_item) == 0:
             error_msg = (


### PR DESCRIPTION
- This is an attempt at resolving some existing ESA indexing issues discovered during pre-WMT24 testing.
- It also resolves inefficiency in #167.
- Adds warning for low score without errors (Tom's idea).
- Update WMT23 message to WMT24 message in dashboard.
- Slightly change the lisder color so that it's more distinguishable from the white gaps between segments.
- Update/simplify ESA+MQM time computation to new indexing.

![image](https://github.com/user-attachments/assets/79b3544e-cfcf-4c94-bc0a-d7ef8ec4db18)

![image](https://github.com/user-attachments/assets/f91a9346-fc5a-489f-8fde-4e0b3109e0bd)
