### PR TITLE
Invalid username crashes Appraise

### DIFF
--- a/Dashboard/views.py
+++ b/Dashboard/views.py
@@ -83,6 +83,11 @@ def sso_login(request, username, password):
         logout(request)
 
     user = authenticate(username=username, password=password)
+    
+    # login failed
+    if user is None:
+        return redirect('dashboard')
+
     login(request, user)
 
     LOGGER.info(


### PR DESCRIPTION
During various testing I noticed that when one uses a username that doesn't exist, it crashes Appraise as in the screenshot. This happens because the `authenticate` function assumes that the user will be valid. The reason this is not good is because it tells the user nothing about what the problem is.

![image](https://github.com/user-attachments/assets/4a06cf89-ae88-4d22-94dd-16cd2a506f2e)

This PR is really simple. On incorrect login (username or password), it just redidrects the user to the dashboard which will display empty login.

![image](https://github.com/user-attachments/assets/f4d1d965-46ec-4562-a684-34ef94cb5e7b)

As a follow-up, a message could be displayed in dashboard that the login failed. It seems that `redirect` can take optional arguments but it's not clear to me how to propagate it to the template so I didn't touch it.