### PR TITLE
Misc simplify JSON loading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v4

--- a/EvalData/models/base_models.py
+++ b/EvalData/models/base_models.py
@@ -90,7 +90,7 @@ class ObjectID(models.Model):
 
             _code = '{0}.objects.get(id={1})'.format(self.typeName, self.primaryID)
 
-            # Hack for Python 3.5.2
+            # TODO: Hack
             from EvalData.models import (
                 DataAssessmentTask,
                 DirectAssessmentTask,

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -366,11 +366,7 @@ class DataAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -411,7 +411,7 @@ class DataAssessmentTask(BaseMetadata):
                     print(
                         'Longest targetText',
                         current_length_text,
-                        item['targetText'].encode('utf-8'),
+                        item['targetText'],
                     )
                     max_length_text = current_length_text
 

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -296,7 +296,7 @@ class DirectAssessmentTask(BaseMetadata):
                 if current_length_text > max_length_text:
                     print(
                         current_length_text,
-                        item['targetText'].encode('utf-8'),
+                        item['targetText'],
                     )
                     max_length_text = current_length_text
 

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -257,11 +257,7 @@ class DirectAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -344,7 +344,7 @@ class DirectAssessmentContextTask(BaseMetadata):
                 if current_length_text > max_length_text:
                     print(
                         current_length_text,
-                        item['targetText'].encode('utf-8'),
+                        item['targetText'],
                     )
                     max_length_text = current_length_text
 

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -304,11 +304,7 @@ class DirectAssessmentContextTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -398,11 +398,7 @@ class DirectAssessmentDocumentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -438,7 +438,7 @@ class DirectAssessmentDocumentTask(BaseMetadata):
                 if current_length_text > max_length_text:
                     print(
                         current_length_text,
-                        item['targetText'].encode('utf-8'),
+                        item['targetText'],
                     )
                     max_length_text = current_length_text
 

--- a/EvalData/models/multi_modal_assessment.py
+++ b/EvalData/models/multi_modal_assessment.py
@@ -332,7 +332,7 @@ class MultiModalAssessmentTask(BaseMetadata):
                 if current_length_text > max_length_text:
                     print(
                         current_length_text,
-                        item['targetText'].encode('utf-8'),
+                        item['targetText'],
                     )
                     max_length_text = current_length_text
 

--- a/EvalData/models/multi_modal_assessment.py
+++ b/EvalData/models/multi_modal_assessment.py
@@ -293,11 +293,7 @@ class MultiModalAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))

--- a/EvalData/models/pairwise_assessment.py
+++ b/EvalData/models/pairwise_assessment.py
@@ -269,11 +269,7 @@ class PairwiseAssessmentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))

--- a/EvalData/models/pairwise_assessment_document.py
+++ b/EvalData/models/pairwise_assessment_document.py
@@ -390,11 +390,7 @@ class PairwiseAssessmentDocumentTask(BaseMetadata):
             # TODO: implement proper support for multiple json files in archive.
             for batch_json_file in batch_json_files:
                 batch_content = batch_zip.read(batch_json_file).decode('utf-8')
-                # Python 3.9 removed 'encoding' from json.loads
-                if sys.version_info >= (3, 9, 0):
-                    batch_json = loads(batch_content)
-                else:
-                    batch_json = loads(batch_content, encoding='utf-8')
+                batch_json = loads(batch_content)
 
         else:
             batch_json = loads(str(batch_file.read(), encoding='utf-8'))


### PR DESCRIPTION
- Don't encode long lines so that they are legible.
- Drop support for Python <3.9 which is [end-of-life](https://endoflife.date/python). The commit also turned two CRLF files into LF endings.

Before:
![Screenshot from 2024-08-07 13-24-45](https://github.com/user-attachments/assets/8daf5085-b799-46d6-a93d-5d133aa8a5ea)

After:
![Screenshot from 2024-08-07 13-25-02](https://github.com/user-attachments/assets/289dc09d-bf66-42ef-bb1f-b22ec5bb7882)
