### PR TITLE
create campaign status page for ESA

### DIFF
--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -243,8 +243,12 @@ def campaign_status_esa(campaign) -> str:
     td, th {
         padding: 5px;
     }
-    </style>
+    * {
+    font-family: monospace;
+    }
+    </style>\n
     """
+    out_str += f"<h1>{campaign.campaignName}</h1>\n"
     out_str += "<table>\n"
     out_str += "<tr><th>Username</th><th>Progress</th><th>First Modified</th><th>Last Modified</th><th>Annotation Time</th></tr>\n"
 
@@ -252,12 +256,10 @@ def campaign_status_esa(campaign) -> str:
         for user in team.members.all():
             if user.is_staff:
                 continue
-            
             out_str += "<tr>"
             _data = DirectAssessmentDocumentResult.objects.filter(
                 createdBy=user, completed=True, task__campaign=campaign.id
             )
-
             total_count = None
             if _data:
                 _data_all = DirectAssessmentDocumentTask.objects.filter(campaign=campaign.id)
@@ -274,7 +276,7 @@ def campaign_status_esa(campaign) -> str:
                         break
             if total_count is None:
                 out_str += f"<td>{user.username} 💤</td>"
-                out_str += f"<td>0%</td>"
+                out_str += "<td></td>"
                 out_str += "<td></td>"
                 out_str += "<td></td>"
             else:
@@ -285,8 +287,15 @@ def campaign_status_esa(campaign) -> str:
                 out_str += f"<td>{len(_data)}/{total_count} ({len(_data) / total_count:.0%})</td>"
                 first_modified = min([x.start_time for x in _data])
                 last_modified = max([x.end_time for x in _data])
-                out_str += f"<td>{str(datetime(1970, 1, 1) + seconds_to_timedelta(first_modified)).split('.')[0]}</td>"
-                out_str += f"<td>{str(datetime(1970, 1, 1) + seconds_to_timedelta(last_modified)).split('.')[0]}</td>"
+
+                first_modified_str = str(datetime(1970, 1, 1) + seconds_to_timedelta(first_modified)).split('.')[0]
+                last_modified_str = str(datetime(1970, 1, 1) + seconds_to_timedelta(last_modified)).split('.')[0]
+                # remove seconds
+                first_modified_str = ":".join(first_modified_str.split(":")[:-1]) 
+                last_modified_str = ":".join(last_modified_str.split(":")[:-1])
+
+                out_str += f"<td>{first_modified_str}</td>"
+                out_str += f"<td>{last_modified_str}</td>"
 
                 times = collections.defaultdict()
                 for item in _data:

--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -260,26 +260,14 @@ def campaign_status_esa(campaign) -> str:
             _data = DirectAssessmentDocumentResult.objects.filter(
                 createdBy=user, completed=True, task__campaign=campaign.id
             )
-            total_count = None
-            if _data:
-                _data_all = DirectAssessmentDocumentTask.objects.filter(campaign=campaign.id)
-                # brute-force try to find if any task has at least one item annotated by this user
-                for task in _data_all:
-                    for item in task.items.all():
-                        item = DirectAssessmentDocumentResult.objects.filter(
-                            item=item, createdBy=user
-                        ).last()
-                        if item:
-                            total_count = task.items.count()
-                            break
-                    if total_count:
-                        break
-            if total_count is None:
+            if not _data:
                 out_str += f"<td>{user.username} 💤</td>"
                 out_str += "<td></td>"
                 out_str += "<td></td>"
                 out_str += "<td></td>"
             else:
+                task = DirectAssessmentDocumentTask.objects.filter(id=_data[0].task_id).first()
+                total_count = task.items.count()
                 if total_count == len(_data):
                     out_str += f"<td>{user.username} ✅</td>"
                 else:

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -263,13 +263,16 @@ class DirectAssessmentDocumentTask(BaseMetadata):
             doc_items_results,
         """
 
-        # get all items (100) and try to find resul
+        # get all items and try to find a matching result
+        # TODO: probably can be optimized better
+
+        items_user = DirectAssessmentDocumentResult.objects.filter(
+            activated=False, completed=True, createdBy=user
+        )
         all_items = [
             (
                 item,
-                DirectAssessmentDocumentResult.objects.filter(
-                    item=item, activated=False, completed=True, createdBy=user
-                ).last(),
+                items_user.filter(item=item).last(),
             )
             for item in self.items.all().order_by('id')
         ]


### PR DESCRIPTION
This hijacks the campaign-status page for ESA which now has different requirements.

<img width="887" height="778" alt="image" src="https://github.com/user-attachments/assets/d1ac06bc-3269-4b2a-88d7-5799751c9caf" />


This is not bad per-se. The one real bad thing is finding all the assigned items. I've been unable to locate the assigned task otherwise (task.assignedTo and task.createdBy doesn't work)

The offending code:
```
                total_count = None
                _data_all = DirectAssessmentDocumentTask.objects.filter(campaign=campaign.id)
                # brute-force try to find if any task has at least one item annotated by this user
                for task in _data_all:
                    for item in task.items.all():
                        item = DirectAssessmentDocumentResult.objects.filter(
                            item=item, createdBy=user
                        ).last()
                        if item:
                            total_count = task.items.count()
                            break
                    if total_count:
                        break
```

The `DirectAssessmentDocumentTask.get_task_for_user(..)` sounds like it should do exactly what we want but it just returns `None` (because `assignedTo` is always None).