### PR TITLE
Bulk changes regarding Instructions, Confirmation tokens, and Status View

### DIFF
--- a/Appraise/urls.py
+++ b/Appraise/urls.py
@@ -188,8 +188,8 @@ urlpatterns = [
         name='pairwise-assessment-document',
     ),
     re_path(
-        r'^campaign-status/(?P<campaign_name>[a-zA-Z0-9]+)/'
-        r'(?P<sort_key>[0123456])?/?$',
+        r'^campaign-status/(?P<campaign_name>[a-zA-Z0-9]+(,[a-zA-Z0-9]+))*/'
+        r'(?P<sort_key>[a-zA-Z0-9_])?/?$',
         campaign_views.campaign_status,
         name='campaign_status',
     ),

--- a/Dashboard/utils.py
+++ b/Dashboard/utils.py
@@ -146,20 +146,20 @@ def run_quality_control(username):
         # File "scipy/stats/stats.py", line 4865, in mannwhitneyu
         #   raise ValueError(
         #     'All numbers are identical in mannwhitneyu')
+        # In this case, let's consider it a failed QC.
         except ValueError:
-            pass
+            _pvalue = 1
 
     # Compute the total annotation time
-    _durations = [x[1] - x[0] for x in _data]
-    annotation_time = sum(_durations) if _durations else None
+    # Be very generous, essentially last action - first action (not individual times)
+    times = [x[1] for x in _data] + [x[0] for x in _data]
+    annotation_time = max(times) - min(times) if times else 0
 
     print(
         f"User '{username}', items= {len(_x)}, p-value= {pvalue}, time= {annotation_time}"
     )
 
-    return (
-        pvalue is not None
-        and pvalue <= MAX_WILCOXON_PVALUE
-        and annotation_time is not None
-        and annotation_time >= MIN_ANNOTATION_TIME
+    return annotation_time >= MIN_ANNOTATION_TIME and (
+        pvalue is None or
+        pvalue <= MAX_WILCOXON_PVALUE
     )

--- a/EvalView/templates/EvalView/_instructions-esa.html
+++ b/EvalView/templates/EvalView/_instructions-esa.html
@@ -16,6 +16,9 @@
       <li><strong>Missing content</strong>: If something is missing, highlight the word <b style="font-family: monospace, monospace;">[MISSING]</b> to mark the error. </li>
       <li><strong>Tip</strong>: Highlight the word or general area of the error (it doesn't need to be exact). Use multiple highlights for different errors.</li>
       <li><strong>Tip</strong>: Pay particular attention to translation consistency between texts across the whole document.</li>
+      <li><strong>Tip</strong>: If the translation is in the wrong language, mark it fully and assign it 0%</li>
+      <li><strong>Tip</strong>: If the translation contains additional text (e.g. "Here is the translation") or alternative secondary translation, mark it as a major error.</li>
+
       <li><strong>Score the translation</strong>: After marking errors, please use the slider and set an overall score based on meaning preservation and general quality:</li>
         <ul>
           <li>0: <strong>Broken/poor</strong> translation.</li>


### PR DESCRIPTION
- Resolves #210 by relaxing the pass check for QC, especially when there is no `BAD` in a campaign.
- Resolves #211 by updating the instructions
- Adds back sort_key to the campaign status page view (accidentally removed before)
- Adds multi-campaign support to campaign status page view (simply separate campaign keys with comma `,`)