### PR TITLE
Download results in admin view

### DIFF
--- a/Campaign/admin.py
+++ b/Campaign/admin.py
@@ -11,14 +11,18 @@ from Campaign.models import CampaignData
 from Campaign.models import CampaignTeam
 from Campaign.models import TrustedUser
 from EvalData.admin import BaseMetadataAdmin
-
+from django.http import HttpResponse
+import csv
+import zipfile
+from io import StringIO
+import importlib
 
 class DropdownFilter(AllValuesFieldListFilter):
     """
     Experimental dropdown filter.
     """
 
-    template = 'Campaign/filter_select.html'
+    template = "Campaign/filter_select.html"
 
 
 class CampaignTeamAdmin(BaseMetadataAdmin):
@@ -27,33 +31,33 @@ class CampaignTeamAdmin(BaseMetadataAdmin):
     """
 
     list_display = [
-        'teamName',
-        'owner',
-        'teamMembers',
-        'requiredAnnotations',
-        'requiredHours',
-        'completionStatus',
+        "teamName",
+        "owner",
+        "teamMembers",
+        "requiredAnnotations",
+        "requiredHours",
+        "completionStatus",
     ] + BaseMetadataAdmin.list_display  # type: ignore
-    list_filter = ['owner'] + BaseMetadataAdmin.list_filter  # type: ignore
+    list_filter = ["owner"] + BaseMetadataAdmin.list_filter  # type: ignore
     search_fields = [
-        'teamName',
-        'owner__username',
-        'owner__first_name',
-        'owner__last_name',
+        "teamName",
+        "owner__username",
+        "owner__first_name",
+        "owner__last_name",
     ] + BaseMetadataAdmin.search_fields  # type: ignore
 
-    filter_horizontal = ['members']
+    filter_horizontal = ["members"]
 
     fieldsets = (
         (
             None,
             {
-                'fields': (
-                    'teamName',
-                    'owner',
-                    'members',
-                    'requiredAnnotations',
-                    'requiredHours',
+                "fields": (
+                    "teamName",
+                    "owner",
+                    "members",
+                    "requiredAnnotations",
+                    "requiredHours",
                 )
             },
         ),
@@ -66,22 +70,22 @@ class CampaignDataAdmin(BaseMetadataAdmin):
     """
 
     list_display = [
-        'dataName',
-        'market',
-        'metadata',
-        'dataValid',
-        'dataReady',
+        "dataName",
+        "market",
+        "metadata",
+        "dataValid",
+        "dataReady",
     ] + BaseMetadataAdmin.list_display  # type: ignore
     list_filter = [
-        'dataValid',
-        'dataReady',
+        "dataValid",
+        "dataReady",
     ] + BaseMetadataAdmin.list_filter  # type: ignore
     search_fields = [
         # nothing model specific
     ] + BaseMetadataAdmin.search_fields  # type: ignore
 
     fieldsets = (
-        (None, {'fields': ('dataFile', 'market', 'metadata')}),
+        (None, {"fields": ("dataFile", "market", "metadata")}),
     ) + BaseMetadataAdmin.fieldsets  # type: ignore
 
 
@@ -90,7 +94,8 @@ class CampaignAdmin(BaseMetadataAdmin):
     Model admin for Campaign instances.
     """
 
-    list_display = ['campaignName'] + BaseMetadataAdmin.list_display + ['id']  # type: ignore
+    list_display = ["campaignName"] + \
+        BaseMetadataAdmin.list_display + ["id"]  # type: ignore
     list_filter = [
         # nothing model specific
     ] + BaseMetadataAdmin.list_filter  # type: ignore
@@ -98,22 +103,72 @@ class CampaignAdmin(BaseMetadataAdmin):
         # nothing model specific
     ] + BaseMetadataAdmin.search_fields  # type: ignore
 
-    filter_horizontal = ['batches']
+    filter_horizontal = ["batches"]
 
     fieldsets = (
         (
             None,
             {
-                'fields': (
-                    'campaignName',
-                    'packageFile',
-                    'teams',
-                    'batches',
-                    'campaignOptions',
+                "fields": (
+                    "campaignName",
+                    "packageFile",
+                    "teams",
+                    "batches",
+                    "campaignOptions",
                 )
             },
         ),
     ) + BaseMetadataAdmin.fieldsets  # type: ignore
+
+
+    actions = ["export_results"]
+
+    def _retrieve_csv(self, current_campaign):
+        # Get the task type  corresponding to the campaign
+        qs_name = current_campaign.get_campaign_type().lower()
+        qs_attr = "evaldata_{0}_campaign".format(qs_name)
+        qs_obj = getattr(current_campaign, qs_attr, None)
+        cls = type(qs_obj.all()[0])
+        cls_name = cls.__name__
+        cls_name = cls_name.replace("Task", "Result")
+        module = importlib.import_module(cls.__module__)
+        cls = getattr(module, cls_name)
+
+        # Now get the content
+        f = StringIO()
+        writer = csv.writer(f)
+        csv_content = cls.get_system_data(current_campaign.id, extended_csv=True)
+        for r in csv_content:
+            writer.writerow(r)
+
+        f.seek(0)
+        return f
+
+
+    def export_results(self, request, queryset):
+        if len(queryset) == 1:
+            current_campaign = queryset[0]
+            csv_content = self._retrieve_csv(current_campaign)
+            filename = f"results_{current_campaign.campaignName}.csv"
+            response = HttpResponse(csv_content, content_type="text/csv")
+            response["Content-Disposition"] = f"attachment; filename={filename}"
+        else:
+            response = HttpResponse(content_type='application/zip')
+            response['Content-Disposition'] = 'attachment; filename="campaign_results.zip"'
+
+            # Create a zip file with selected objects
+            with zipfile.ZipFile(response, 'w') as zipf:
+                for current_campaign in queryset:
+
+                    csv_content = self._retrieve_csv(current_campaign)
+                    # Add objects to the zip file, customize as per your model's data
+                    # For example, you can add an object's name and description to a text file in the zip
+                    filename = f"results_{current_campaign.campaignName}.csv"
+                    zipf.writestr(filename, csv_content.getvalue())
+        return response
+
+    export_results.short_description = "Download results"
+
 
 
 class TrustedUserAdmin(admin.ModelAdmin):
@@ -121,16 +176,16 @@ class TrustedUserAdmin(admin.ModelAdmin):
     Model admin for Campaign instances.
     """
 
-    list_display = ['user', 'campaign']
+    list_display = ["user", "campaign"]
     list_filter = [
-        ('campaign__campaignName', DropdownFilter),
-        #      'campaign'
+        ("campaign__campaignName", DropdownFilter),
+        #      "campaign"
     ]
     search_fields = [  # type: ignore
         # nothing model specific
     ]
 
-    fieldsets = ((None, {'fields': ('user', 'campaign')}),)
+    fieldsets = ((None, {"fields": ("user", "campaign")}),)
 
 
 admin.site.register(CampaignTeam, CampaignTeamAdmin)

--- a/Campaign/views.py
+++ b/Campaign/views.py
@@ -264,10 +264,15 @@ def campaign_status_esa(campaign) -> str:
     """
     out_str += f"<h1>{campaign.campaignName}</h1>\n"
     out_str += "<table>\n"
-    out_str += "<tr>" + "".join(
-        f"<th>{x}</th>" for x in ["Username", "Progress", "First Modified", "Last Modified", "Time (Last-First)", "Time (Real)"]
-    ) + "</tr>\n"
-    
+    out_str += """<tr>
+<th>Username</th>
+<th>Progress</th>
+<th>First Modified</th>
+<th>Last Modified</th>
+<th style="cursor: pointer" title="Very coarse upper bound estimate between the last and the first interaction with the system.">Time (Coarse ❔)</th>
+<th style="cursor: pointer" title="Sum of times between any two interactions that are not longer than 10 minutes.">Time (Real ❔)</th>
+</tr>\n
+""" 
     for team in campaign.teams.all():
         for user in team.members.all():
             if user.is_staff:
@@ -352,9 +357,9 @@ def campaign_status_esa(campaign) -> str:
                 annotation_time_upper = f'{int(floor(annotation_time_upper / 3600)):0>2d}h {int(floor((annotation_time_upper % 3600) / 60)):0>2d}m'
                 out_str += f"<td>{annotation_time_upper}</td>"
 
-                # consider time that's in any action within 5 minutes
+                # consider time that's in any action within 10 minutes
                 times = sorted([item.start_time for item in _data] + [item.end_time for item in _data])
-                annotation_time = sum([b-a for a, b in zip(times, times[1:]) if (b-a) < 5*60])
+                annotation_time = sum([b-a for a, b in zip(times, times[1:]) if (b-a) < 10*60])
                 annotation_time = f'{int(floor(annotation_time / 3600)):0>2d}h {int(floor((annotation_time % 3600) / 60)):0>2d}m'
 
                 out_str += f"<td>{annotation_time}</td>"

--- a/EvalData/models/data_assessment.py
+++ b/EvalData/models/data_assessment.py
@@ -890,18 +890,15 @@ class DataAssessmentResult(BaseMetadata):
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 
-            _fixed_ids = result[1].replace('Transformer+R2L', 'Transformer_R2L')
-            _fixed_ids = _fixed_ids.replace('R2L+Back', 'R2L_Back')
-
             if expand_multi_sys:
-                system_ids = _fixed_ids.split('+')
+                system_ids = result[1].split('+')
 
                 for system_id in system_ids:
                     data = (user_id,) + (system_id,) + result[2:]
                     system_data.append(data)
 
             else:
-                system_id = _fixed_ids
+                system_id = result[1]
                 data = (user_id,) + (system_id,) + result[2:]
                 system_data.append(data)
 

--- a/EvalData/models/direct_assessment.py
+++ b/EvalData/models/direct_assessment.py
@@ -751,18 +751,15 @@ class DirectAssessmentResult(BaseMetadata):
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 
-            _fixed_ids = result[1].replace('Transformer+R2L', 'Transformer_R2L')
-            _fixed_ids = _fixed_ids.replace('R2L+Back', 'R2L_Back')
-
             if expand_multi_sys:
-                system_ids = _fixed_ids.split('+')
+                system_ids = result[1].split('+')
 
                 for system_id in system_ids:
                     data = (user_id,) + (system_id,) + result[2:]
                     system_data.append(data)
 
             else:
-                system_id = _fixed_ids
+                system_id = result[1]
                 data = (user_id,) + (system_id,) + result[2:]
                 system_data.append(data)
 

--- a/EvalData/models/direct_assessment_context.py
+++ b/EvalData/models/direct_assessment_context.py
@@ -836,11 +836,8 @@ class DirectAssessmentContextResult(BaseMetadata):
         for result in qs.values_list(*attributes_to_extract):
             user_id = result[0]
 
-            _fixed_ids = result[1].replace('Transformer+R2L', 'Transformer_R2L')
-            _fixed_ids = _fixed_ids.replace('R2L+Back', 'R2L_Back')
-
             if expand_multi_sys:
-                system_ids = _fixed_ids.split('+')
+                system_ids = result[1].split('+')
 
                 for system_id in system_ids:
                     data = (user_id,) + (system_id,) + result[2:]

--- a/EvalData/models/direct_assessment_document.py
+++ b/EvalData/models/direct_assessment_document.py
@@ -608,9 +608,9 @@ class DirectAssessmentDocumentResult(BaseAssessmentResult):
         )
 
         if is_esa_or_mqm:
-            # consider time that's in any action within 5 minutes
+            # consider time that's in any action within 10 minutes
             times = sorted([item.start_time for item in results] + [item.end_time for item in results])
-            annotation_time = sum([b-a for a, b in zip(times, times[1:]) if (b-a) < 5*60])
+            annotation_time = sum([b-a for a, b in zip(times, times[1:]) if (b-a) < 10*60])
             return seconds_to_timedelta(annotation_time)
         else:
             timestamps = []

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 


### PR DESCRIPTION
This PR adds a support to download results from the admin view and resolves #51.

<img width="843" height="735" alt="image" src="https://github.com/user-attachments/assets/b6bd30e0-da8b-4b6d-8602-ed1ff12e7fe9" />

- This PR is a rebased version of #120. Thank you @seblemaguer, I put you as an author of the main commit.
- There were a minor tweaks needed to make it work. It looks as in the screenshot. If more than one campaigns are selected, then the output is a zip file.
- I didn't include writing the CSV headers because there are many functions that output CSV and should be part of a general system output overhaul (e.g. turn everything into JSON and output everything by default instead of per-task basis)